### PR TITLE
fix: prevent exceeding precision 18

### DIFF
--- a/api/service/coingecko/ticker.go
+++ b/api/service/coingecko/ticker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/dezswap/dezswap-api/api/service"
+	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"math"
@@ -224,14 +225,14 @@ where ps.chain_id = ?
 
 	for i, t := range tickers {
 		var baseVolume types.Dec
-		if v, err := types.NewDecFromStr(t.BaseVolume); err != nil {
+		if v, err := pkg.NewDecFromStrWithTruncate(t.BaseVolume); err != nil {
 			return nil, errors.Wrap(err, "tickerService.tickers")
 		} else {
 			baseVolume = types.NewDecFromIntWithPrec(v.TruncateInt(), int64(t.BaseDecimals))
 		}
 
 		var targetVolume types.Dec
-		if v, err := types.NewDecFromStr(t.TargetVolume); err != nil {
+		if v, err := pkg.NewDecFromStrWithTruncate(t.TargetVolume); err != nil {
 			return nil, errors.Wrap(err, "tickerService.tickers")
 		} else {
 			targetVolume = types.NewDecFromIntWithPrec(v.TruncateInt(), int64(t.TargetDecimals))

--- a/api/service/coinmarketcap/ticker.go
+++ b/api/service/coinmarketcap/ticker.go
@@ -3,6 +3,7 @@ package coinmarketcap
 import (
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/dezswap/dezswap-api/api/service"
+	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"strings"
@@ -51,11 +52,11 @@ func (s tickerService) Get(key string) (*Ticker, error) {
 	totalQuoteVolume := types.ZeroDec()
 	lastPrice := "0"
 	for _, t := range tickers {
-		baseVolume, err := types.NewDecFromStr(t.BaseVolume)
+		baseVolume, err := pkg.NewDecFromStrWithTruncate(t.BaseVolume)
 		if err != nil {
 			return nil, err
 		}
-		quoteVolume, err := types.NewDecFromStr(t.QuoteVolume)
+		quoteVolume, err := pkg.NewDecFromStrWithTruncate(t.QuoteVolume)
 		if err != nil {
 			return nil, err
 		}
@@ -154,11 +155,11 @@ order by ps.timestamp asc
 	}
 	tickerMap := make(map[string]tickerWithDec)
 	for _, t := range tickers {
-		baseVolume, err := types.NewDecFromStr(t.BaseVolume)
+		baseVolume, err := pkg.NewDecFromStrWithTruncate(t.BaseVolume)
 		if err != nil {
 			return nil, err
 		}
-		quoteVolume, err := types.NewDecFromStr(t.QuoteVolume)
+		quoteVolume, err := pkg.NewDecFromStrWithTruncate(t.QuoteVolume)
 		if err != nil {
 			return nil, err
 		}

--- a/api/service/stat.go
+++ b/api/service/stat.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/dezswap/dezswap-api/pkg"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -173,27 +174,27 @@ where ps.chain_id = ? and ps.timestamp > extract(epoch from now()-?::interval)
 }
 
 func (s *statService) sumPairStat(stat db.PairStat, sumStatMap map[string][countOfStatType]types.Dec) error {
-	volume0, err := types.NewDecFromStr(stat.Volume0InPrice)
+	volume0, err := pkg.NewDecFromStrWithTruncate(stat.Volume0InPrice)
 	if err != nil {
 		return err
 	}
-	volume1, err := types.NewDecFromStr(stat.Volume1InPrice)
+	volume1, err := pkg.NewDecFromStrWithTruncate(stat.Volume1InPrice)
 	if err != nil {
 		return err
 	}
-	commission0, err := types.NewDecFromStr(stat.Commission0InPrice)
+	commission0, err := pkg.NewDecFromStrWithTruncate(stat.Commission0InPrice)
 	if err != nil {
 		return err
 	}
-	commission1, err := types.NewDecFromStr(stat.Commission1InPrice)
+	commission1, err := pkg.NewDecFromStrWithTruncate(stat.Commission1InPrice)
 	if err != nil {
 		return err
 	}
-	liquidity0, err := types.NewDecFromStr(stat.Liquidity0InPrice)
+	liquidity0, err := pkg.NewDecFromStrWithTruncate(stat.Liquidity0InPrice)
 	if err != nil {
 		return err
 	}
-	liquidity1, err := types.NewDecFromStr(stat.Liquidity1InPrice)
+	liquidity1, err := pkg.NewDecFromStrWithTruncate(stat.Liquidity1InPrice)
 	if err != nil {
 		return err
 	}

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -1,0 +1,31 @@
+package pkg
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/types"
+	"strings"
+)
+
+func NewDecFromStrWithTruncate(input string) (types.Dec, error) {
+	truncatedInput := truncateDecimal(input)
+	dec, err := types.NewDecFromStr(truncatedInput)
+	if err != nil {
+		return types.Dec{}, fmt.Errorf("failed to parse decimal: %w", err)
+	}
+
+	return dec, nil
+}
+
+func truncateDecimal(input string) string {
+	parts := strings.Split(input, ".")
+	if len(parts) == 1 {
+		return input
+	}
+
+	fractional := parts[1]
+	if len(fractional) > types.Precision {
+		fractional = fractional[:types.Precision]
+	}
+
+	return parts[0] + "." + fractional
+}

--- a/pkg/util_test.go
+++ b/pkg/util_test.go
@@ -1,0 +1,32 @@
+package pkg
+
+import (
+	"testing"
+)
+
+func Test_TruncateDecimal(t *testing.T) {
+	tcs := []struct {
+		input    string
+		expected string
+	}{
+		{"0.0035453499282647604", "0.003545349928264760"},
+		{"1.1234567890123456789", "1.123456789012345678"},
+		{"123.4567890123456789", "123.4567890123456789"},
+		{"123456", "123456"},
+		{"0.0000000000000000001", "0.000000000000000000"},
+		{"-1.0000000000000000009", "-1.000000000000000000"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			result := truncateDecimal(tc.input)
+			if result != tc.expected {
+				t.Errorf("expected %s but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestSuite(t *testing.T) {
+	t.Run("TestTruncateDecimal", Test_TruncateDecimal)
+}


### PR DESCRIPTION
Major Reviewer: @jaeminDelightlabs @jbamlee 

## Cause
- commission in price exceeds max decimal places in cosmos-sdk.types.Decimal

## Solution
- truncate decimal before parsing