### PR TITLE
ci: push base image to GAR only if git-tagged

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Load, tag and push image to GAR
         run: |
-          docker load ${{ runner.temp }}/dezswap-api-latest.tar
+          docker load -i ${{ runner.temp }}/dezswap-api-latest.tar
           tag=${{ needs.build.outputs.git-tag }}
           docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$tag
           docker push $GCP_GAR_REPOSITORY/dezswap-api:$tag

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -68,10 +68,14 @@ jobs:
       - name: Get Git tag if present
         id: get-git-tag
         run: |
-          GIT_TAG=$(git tag --points-at HEAD | head -n 1 | sed 's/^v//')
-          if [[ -n "$GIT_TAG" ]]; then
-            echo $GIT_TAG
-            echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          GIT_TAG=$(git tag --points-at HEAD | head -n 1)
+          echo "Git tag: $GIT_TAG"
+          if [[ "$GIT_TAG" == v* ]]; then
+            VERSION_TAG=$(echo "$GIT_TAG" | sed 's/^v//')
+            echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "No valid version tag (v*) found. Skipping push to GAR."
+            echo "tag=" >> $GITHUB_OUTPUT
           fi
 
       - name: Test, build and package base image

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -137,6 +137,7 @@ jobs:
   push_to_ecr:
     name: Push images to ECR
     needs: build
+    if: ${{ needs.build.outputs.git-tag == '' }}
     environment: production
     runs-on: ubuntu-latest
     steps:
@@ -176,47 +177,33 @@ jobs:
   push_to_gar:
     name: Push images to Google Artifact Registry
     needs: build
+    if: ${{ needs.build.outputs.git-tag != '' }}
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Check if tag is present
-        id: check-git-tag
-        run: |
-          if [[ -z "${{ needs.build.outputs.git-tag }}" ]]; then
-            echo "No Git tag found. Skipping GAR push."
-            echo "git-tag-exists=false" >> $GITHUB_OUTPUT
-          else
-            echo "git-tag-exists=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Authenticate to GCP
-        if: steps.check.outputs.git-tag-exists == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Setup gcloud
-        if: steps.check.outputs.git-tag-exists == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Authenticate to Repo
-        if: steps.check.outputs.git-tag-exists == 'true'
         run: |
           gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Download artifact
-        if: steps.check.outputs.git-tag-exists == 'true'
         uses: actions/download-artifact@v4
         with:
           name: docker-images
           path: ${{ runner.temp }}
 
       - name: Load, tag and push image to GAR
-        if: steps.check.outputs.git-tag-exists == 'true'
         run: |
           docker load ${{ runner.temp }}/dezswap-api-latest.tar
-          tag=${{ needs.build.outputs.git_tag }}
+          tag=${{ needs.build.outputs.git-tag }}
           docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$tag
           docker push $GCP_GAR_REPOSITORY/dezswap-api:$tag
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Build and package network-specific images
         id: build-final-images
+        if: steps.get-git-tag.outputs.tag == ''
         working-directory: .
         env:
           DIMENSION_CONFIG: ${{ secrets.DIMENSION_CONFIG }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -57,10 +57,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image-tags: ${{ steps.build-final-images.outputs.image-tags }}
-
+      git-tag: ${{ steps.get-git-tag.outputs.tag }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get Git tag if present
+        id: get-git-tag
+        run: |
+          GIT_TAG=$(git tag --points-at HEAD | head -n 1 | sed 's/^v//')
+          if [[ -n "$GIT_TAG" ]]; then
+            echo $GIT_TAG
+            echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          fi
 
       - name: Test, build and package base image
         id: build-base-image
@@ -167,40 +179,46 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Check if tag is present
+        id: check-git-tag
+        run: |
+          if [[ -z "${{ needs.build.outputs.git-tag }}" ]]; then
+            echo "No Git tag found. Skipping GAR push."
+            echo "git-tag-exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "git-tag-exists=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Authenticate to GCP
+        if: steps.check.outputs.git-tag-exists == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Setup gcloud
+        if: steps.check.outputs.git-tag-exists == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Authenticate to Repo
+        if: steps.check.outputs.git-tag-exists == 'true'
         run: |
           gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Download artifact
+        if: steps.check.outputs.git-tag-exists == 'true'
         uses: actions/download-artifact@v4
         with:
           name: docker-images
           path: ${{ runner.temp }}
 
       - name: Load, tag and push image to GAR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        if: steps.check.outputs.git-tag-exists == 'true'
         run: |
-          # Load all saved Docker images
-          for tar in ${{ runner.temp }}/dezswap-api-*.tar; do
-            docker load -i "$tar"
-          done
-
-          # Retag and push each loaded image
-          for image in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep ^dezswap-api:); do
-            tag=$(echo $image | cut -d ':' -f 2)
-            docker tag $image $GCP_GAR_REPOSITORY/dezswap-api:$tag
-            docker push $GCP_GAR_REPOSITORY/dezswap-api:$tag
-          done
+          docker load ${{ runner.temp }}/dezswap-api-latest.tar
+          tag=${{ needs.build.outputs.git_tag }}
+          docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$tag
+          docker push $GCP_GAR_REPOSITORY/dezswap-api:$tag
 
   deploy_to_ecs:
     name: Deploy API


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer: @jhlee-young 

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- With the GKE deployment of dezswap-api, network-specific images will no longer be used. Instead the base image will be used for all networks, and the network-specific configurations will be injected via Helm.
- dezswap-api will also adopt version tags, and the same versions will be attached as docker image tags.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->

- If a git tag is not detected, `push_to_ecr` (and as a result, `deploy_to_ecs`) will be triggered. ([Test results](https://github.com/dezswap/dezswap-api/actions/runs/15316058907))
- If a git tag is detected, `push_to_gar` will be triggered and the network-specific docker images will not be built. ([Test results](https://github.com/dezswap/dezswap-api/actions/runs/15316118252))

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?