### PR TITLE
feat: support querying txs for multiple tokens

### DIFF
--- a/api/controller/dashboard/dashboard_test.go
+++ b/api/controller/dashboard/dashboard_test.go
@@ -1,0 +1,64 @@
+package dashboard
+
+import (
+	service "github.com/dezswap/dezswap-api/api/service/dashboard"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTokenAddrs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []service.Addr
+	}{
+		{
+			name:     "Empty String",
+			input:    "",
+			expected: []service.Addr(nil),
+		},
+		{
+			name:     "Empty Tokens",
+			input:    ", ",
+			expected: []service.Addr(nil),
+		},
+		{
+			name:     "A Single Token",
+			input:    "axpla",
+			expected: []service.Addr{"axpla"},
+		},
+		{
+			name:     "Multiple Tokens",
+			input:    "axpla,xpla1abcd,ibc/ABCD1234",
+			expected: []service.Addr{"axpla", "xpla1abcd", "ibc/ABCD1234"},
+		},
+		{
+			name:     "Multiple Tokens with Whitespace",
+			input:    "axpla, xpla1abcd ,ibc/ABCD1234",
+			expected: []service.Addr{"axpla", "xpla1abcd", "ibc/ABCD1234"},
+		},
+		{
+			name:     "Multiple Tokens Including Empty One",
+			input:    "axpla,,ibc/ABCD1234",
+			expected: []service.Addr{"axpla", "ibc/ABCD1234"},
+		},
+		{
+			name:     "Multiple Tokens Including Whitespace Token",
+			input:    "axpla,  ,ibc/ABCD1234",
+			expected: []service.Addr{"axpla", "ibc/ABCD1234"},
+		},
+		{
+			name:     "Starts with Whitespace",
+			input:    " axpla,  ,ibc/ABCD1234",
+			expected: []service.Addr{"axpla", "ibc/ABCD1234"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseTokenAddrs(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -742,7 +742,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Token address",
+                        "description": "Token addresses",
                         "name": "token",
                         "in": "query"
                     },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -731,7 +731,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Token address",
+                        "description": "Token addresses",
                         "name": "token",
                         "in": "query"
                     },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -808,7 +808,7 @@ paths:
         in: query
         name: pool
         type: string
-      - description: Token address
+      - description: Token addresses
         in: query
         name: token
         type: string

--- a/api/service/dashboard/dashboard.go
+++ b/api/service/dashboard/dashboard.go
@@ -1116,15 +1116,15 @@ func (d *dashboard) Txs(txType TxType, addr ...Addr) (Txs, error) {
 }
 
 // TxsOfToken implements Dashboard.
-func (d *dashboard) TxsOfToken(txType TxType, addr Addr) (Txs, error) {
+func (d *dashboard) TxsOfToken(txType TxType, tokenAddrs ...Addr) (Txs, error) {
 	m := parser.ParsedTx{}
 	subQuery := d.DB.Model(&m).Select("*").Where("chain_id = ?", d.chainId).Order("timestamp DESC").Limit(100)
 
 	if txType != TX_TYPE_ALL {
 		subQuery = subQuery.Where("type = ?", string(txType))
 	}
-	if len(addr) > 0 {
-		subQuery = subQuery.Where("asset0 = ? OR asset1 = ?", string(addr), string(addr))
+	if len(tokenAddrs) > 0 {
+		subQuery = subQuery.Where("asset0 IN ? OR asset1 IN ?", tokenAddrs, tokenAddrs)
 	}
 
 	query := d.DB.Select(`

--- a/api/service/dashboard/interfaces.go
+++ b/api/service/dashboard/interfaces.go
@@ -17,7 +17,7 @@ type Dashboard interface {
 	TokenPrices(addr Addr, itv Duration) (TokenChart, error)
 
 	Txs(txType TxType, addr ...Addr) (Txs, error)
-	TxsOfToken(txType TxType, token Addr) (Txs, error)
+	TxsOfToken(txType TxType, tokenAddrs ...Addr) (Txs, error)
 
 	Volumes(Duration) (Volumes, error)
 	VolumesOf(Addr, Duration) (Volumes, error)


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A recent integration use case required filtering transactions by multiple token addresses. This change extends the API to support that scenario without breaking backward compatibility.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Previously, the endpoint only allowed retrieving transactions for a single token via `token` parameter. Now, it accepts a comma-separated list of token addresses, allowing clients to fetch transactions for multiple tokens in a single request.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?