### PR TITLE
fix(ci): expose build image-tags output via push_to_ecr

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -127,6 +127,8 @@ jobs:
     needs: build
     environment: production
     runs-on: ubuntu-latest
+    outputs:
+      image-tags: ${{ needs.build.outputs.image-tags }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -225,7 +227,7 @@ jobs:
       - name: Parse Image Tags
         id: parse-tags
         run: |
-          printf '${{ needs.build.outputs.image-tags }}' > image_tags.json
+          printf '${{ needs.push_to_ecr.outputs.image-tags }}' > image_tags.json
           IMAGE_TAG=$(jq -r '.["'${{ matrix.service }}'"]' image_tags.json)
           echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer: @aaajhs 

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
The `deploy_to_ecs` job could not access the `image-tags` output from the `build` job.
By passing it through the `push_to_ecr` job, the necessary output can now be retrieved without altering the dependency graph.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?