### PR TITLE
ci: use git tag as image tag for ECR/ECS

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -3,8 +3,6 @@ name: Deploy Dezswap API
 on:
   workflow_run:
     workflows: ["CI"]
-    branches: [main]
-    tags: ["v*"]
     types:
       - completed
 
@@ -27,7 +25,9 @@ permissions:
 jobs:
   check_paths:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.ref, 'refs/tags/v')
     outputs:
       run_next_job: ${{ steps.check_paths.outputs.run_next_job }}
     steps:
@@ -66,31 +66,23 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Get Git tag if present
+      - name: Get Git tag
         id: get-git-tag
         run: |
           GIT_TAG=$(git tag --points-at HEAD | head -n 1)
-          echo "Git tag: $GIT_TAG"
-          if [[ "$GIT_TAG" == v* ]]; then
-            VERSION_TAG=$(echo "$GIT_TAG" | sed 's/^v//')
-            echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
-          else
-            echo "No valid version tag (v*) found. Skipping push to GAR."
-            echo "tag=" >> $GITHUB_OUTPUT
-          fi
+          echo "Git tag detected: $GIT_TAG"
+          VERSION_TAG=$(echo "$GIT_TAG" | sed 's/^v//')
+          echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
 
       - name: Test, build and package base image
         id: build-base-image
         working-directory: .
         env:
           APP_TYPE: ${{ env.APP_TYPE }}
+          IMAGE_TAG: ${{ steps.get-git-tag.outputs.tag }}
         run: |
           # Test
           make test
-
-          # Get image tag and make persistent
-          IMAGE_TAG=$(git rev-parse --short HEAD)
-          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
           # Build and package base image
           touch config.yml
@@ -104,7 +96,6 @@ jobs:
 
       - name: Build and package network-specific images
         id: build-final-images
-        if: steps.get-git-tag.outputs.tag == ''
         working-directory: .
         env:
           DIMENSION_CONFIG: ${{ secrets.DIMENSION_CONFIG }}
@@ -112,10 +103,8 @@ jobs:
           FETCHHUB_CONFIG: ${{ secrets.FETCHHUB_CONFIG }}
           DORADO_CONFIG: ${{ secrets.DORADO_CONFIG }}
           APP_TYPE: ${{ env.APP_TYPE }}
+          IMAGE_TAG: ${{ steps.get-git-tag.outputs.tag }}
         run: |
-          # Fetch image tag
-          IMAGE_TAG="${{ steps.build-base-image.outputs.image_tag }}"
-
           # Build network-specific images
           configs=("$DIMENSION_CONFIG" "$CUBE_CONFIG" "$FETCHHUB_CONFIG" "$DORADO_CONFIG")
           networks=("dimension" "cube" "fetchhub" "dorado")
@@ -128,7 +117,7 @@ jobs:
             image_tags+=("\"${networks[i]}\": \"$FINAL_IMAGE_TAG\"")
             docker save -o ${{ runner.temp }}/dezswap-api-$FINAL_IMAGE_TAG.tar dezswap-api:$FINAL_IMAGE_TAG
           done
-          
+
           # Create JSON string of all image tags
           image_tags_string=$(IFS=, ; echo "${image_tags[*]}")
           echo "{ ${image_tags_string} }" > image_tags.json
@@ -143,7 +132,6 @@ jobs:
   push_to_ecr:
     name: Push images to ECR
     needs: build
-    if: ${{ needs.build.outputs.git-tag == '' }}
     environment: production
     runs-on: ubuntu-latest
     outputs:
@@ -185,7 +173,6 @@ jobs:
   push_to_gar:
     name: Push images to Google Artifact Registry
     needs: build
-    if: ${{ needs.build.outputs.git-tag != '' }}
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -209,11 +196,12 @@ jobs:
           path: ${{ runner.temp }}
 
       - name: Load, tag and push image to GAR
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.git-tag }}
         run: |
           docker load -i ${{ runner.temp }}/dezswap-api-latest.tar
-          tag=${{ needs.build.outputs.git-tag }}
-          docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$tag
-          docker push $GCP_GAR_REPOSITORY/dezswap-api:$tag
+          docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$IMAGE_TAG
+          docker push $GCP_GAR_REPOSITORY/dezswap-api:$IMAGE_TAG
 
   deploy_to_ecs:
     name: Deploy API


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer: @jhlee-young 

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->

- Streamline the workflows to build one single set of docker images for both ECR and GAR, using git tag value, instead of the commit SHA, as the image tag.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [x] Test enough in your local environment?
  - See https://github.com/dezswap/dezswap-api/actions/runs/15433666409
- [ ] Add related test cases?