### PR TITLE
ci: fix api workflow condition

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,15 +38,16 @@ jobs:
         id: check_branch
         run: |
           branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
+          echo $branches_containing_tag
 
-          echo "run_next_job=true" >> $GITHUB_OUTPUT
 
-          if echo "$branches_containing_tag" | grep -q "^origin/main$"; then
+          if echo "$branches_containing_tag" | grep -q "^ci/change-api-workflow-condition$"; then
             GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
             echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+            echo "run_next_job=true" >> $GITHUB_OUTPUT
           else
             echo "The tag commit is NOT on main branch. Exiting."
-            echo "run_next_job=false" >> $GITHUB_OUTPUT
+            echo "run_next_job=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Check changed file paths
@@ -59,6 +60,8 @@ jobs:
           if [[ -z "$MATCHING_FILES" ]]; then
             echo "no matching file"
             echo "run_next_job=false" >> $GITHUB_OUTPUT
+          else
+            echo "run_next_job=true" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -40,7 +40,7 @@ jobs:
           branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
           echo "Branches containing tag: $branches_containing_tag"
 
-          if echo "$branches_containing_tag" | grep -q "^origin/main$"; then
+          if echo "$branches_containing_tag" | grep -Eq "^(origin/)?main$"; then
             # get version from tag
             GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
             echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -40,17 +40,18 @@ jobs:
           branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
           echo "Branches containing tag: $branches_containing_tag"
 
-          if echo "$branches_containing_tag" | grep -q "^ci/change-api-workflow-condition$"; then
+          if echo "$branches_containing_tag" | grep -q "^origin/main$"; then
             # get version from tag
             GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
             echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
             echo "run_next_job=true" >> $GITHUB_OUTPUT
           else
             echo "The tag commit is NOT on main branch. Exiting."
-            echo "run_next_job=true" >> $GITHUB_OUTPUT
+            echo "run_next_job=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Check changed file paths
+        if: ${{ needs.check_branch.outputs.run_next_job == 'true' }}
         id: check_paths
         run: |
           CHANGED_FILES=$(git diff HEAD~1 --name-only)

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,10 +38,10 @@ jobs:
         id: check_branch
         run: |
           branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
-          echo $branches_containing_tag
-
+          echo "Branches containing tag: $branches_containing_tag"
 
           if echo "$branches_containing_tag" | grep -q "^ci/change-api-workflow-condition$"; then
+            # get version from tag
             GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
             echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
             echo "run_next_job=true" >> $GITHUB_OUTPUT
@@ -61,6 +61,7 @@ jobs:
             echo "no matching file"
             echo "run_next_job=false" >> $GITHUB_OUTPUT
           else
+            echo "matching file $MATCHING_FILES"
             echo "run_next_job=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Check changed file paths
-        if: ${{ needs.check_branch.outputs.run_next_job == 'true' }}
+        if: ${{ steps.check_branch.outputs.run_next_job == 'true' }}
         id: check_paths
         run: |
           CHANGED_FILES=$(git diff HEAD~1 --name-only)

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,10 +1,9 @@
 name: Deploy Dezswap API
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
+    tags:
+      - 'v*'
 
 env:
   APP_TYPE: api
@@ -25,16 +24,30 @@ permissions:
 jobs:
   check_paths:
     runs-on: ubuntu-latest
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.ref, 'refs/tags/v')
     outputs:
       run_next_job: ${{ steps.check_paths.outputs.run_next_job }}
+      tag: ${{ steps.check_branch.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check if tag commit is on main branch
+        id: check_branch
+        run: |
+          branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
+
+          echo "run_next_job=true" >> $GITHUB_OUTPUT
+
+          if echo "$branches_containing_tag" | grep -q "^origin/main$"; then
+            GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
+            echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "The tag commit is NOT on main branch. Exiting."
+            echo "run_next_job=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check changed file paths
         id: check_paths
@@ -46,9 +59,6 @@ jobs:
           if [[ -z "$MATCHING_FILES" ]]; then
             echo "no matching file"
             echo "run_next_job=false" >> $GITHUB_OUTPUT
-          else
-            echo "matching file $MATCHING_FILES"
-            echo "run_next_job=true" >> $GITHUB_OUTPUT
           fi
 
   build:
@@ -58,28 +68,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image-tags: ${{ steps.build-final-images.outputs.image-tags }}
-      git-tag: ${{ steps.get-git-tag.outputs.tag }}
+      tag: ${{ needs.check_paths.outputs.tag }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Get Git tag
-        id: get-git-tag
-        run: |
-          GIT_TAG=$(git tag --points-at HEAD | head -n 1)
-          echo "Git tag detected: $GIT_TAG"
-          VERSION_TAG=$(echo "$GIT_TAG" | sed 's/^v//')
-          echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
 
       - name: Test, build and package base image
         id: build-base-image
         working-directory: .
         env:
           APP_TYPE: ${{ env.APP_TYPE }}
-          IMAGE_TAG: ${{ steps.get-git-tag.outputs.tag }}
+          IMAGE_TAG: ${{ needs.check_paths.outputs.tag }}
         run: |
           # Test
           make test
@@ -103,7 +102,7 @@ jobs:
           FETCHHUB_CONFIG: ${{ secrets.FETCHHUB_CONFIG }}
           DORADO_CONFIG: ${{ secrets.DORADO_CONFIG }}
           APP_TYPE: ${{ env.APP_TYPE }}
-          IMAGE_TAG: ${{ steps.get-git-tag.outputs.tag }}
+          IMAGE_TAG: ${{ needs.check_paths.outputs.tag }}
         run: |
           # Build network-specific images
           configs=("$DIMENSION_CONFIG" "$CUBE_CONFIG" "$FETCHHUB_CONFIG" "$DORADO_CONFIG")
@@ -197,7 +196,7 @@ jobs:
 
       - name: Load, tag and push image to GAR
         env:
-          IMAGE_TAG: ${{ needs.build.outputs.git-tag }}
+          IMAGE_TAG: ${{ needs.build.outputs.tag }}
         run: |
           docker load -i ${{ runner.temp }}/dezswap-api-latest.tar
           docker tag dezswap-api:latest $GCP_GAR_REPOSITORY/dezswap-api:$IMAGE_TAG


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer: @jhlee-young 

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->

- Change condition to trigger when a git tag of format `v*` is pushed.
- Check that the tag exists in the `main` branch, else exit workflow.
- Move tag retrieval to the same step as the branch check.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?