### PR TITLE
ci: remove test from build and tagging

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -85,9 +85,6 @@ jobs:
           APP_TYPE: ${{ env.APP_TYPE }}
           IMAGE_TAG: ${{ needs.check_paths.outputs.tag }}
         run: |
-          # Test
-          make test
-
           # Build and package base image
           touch config.yml
           tag=${{ steps.get-git-tag.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [ "main" ]
-    tags: [ "v*" ]
     paths-ignore: [ 'README.md', 'LICENSE', 'config.example.yml', '.gitignore', '.github/CODEOWNERS', '.github/pull_request_template.md' ]
   pull_request:
     branches: [ "*" ]

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -79,7 +79,6 @@ jobs:
           DORADO_CONFIG: ${{ secrets.DORADO_CONFIG }}
           APP_TYPE: ${{ env.APP_TYPE }}
         run: |
-          make test
           IMAGE_TAG=`git rev-parse --short HEAD`
           touch config.yml
           docker build --build-arg APP_TYPE=$APP_TYPE -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Deployment workflows ran tests previously. Since CI already covers tests during merge, running them again was redundant.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Removed test from deployment workflows to avoid duplication and speed up

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?