### PR TITLE
fix: cast timestamp type to integer to prevent parsing error

### DIFF
--- a/api/v1/service/dashboard/dashboard_test.go
+++ b/api/v1/service/dashboard/dashboard_test.go
@@ -7,11 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"strconv"
 	"testing"
+	"time"
 )
 
-var testChainID = "testchain-1"
-var testContract = "test1abcd"
+var (
+	testChainID           = "testchain-1"
+	testPairContractAddr1 = "test1abcd"
+
+	testPairContractAddr2 = "test1efgh"
+	testTokenAddr         = "xerc20:ABCD"
+	tsData                = time.Time{}
+)
 
 func SetupDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -25,8 +33,51 @@ func SetupDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err)
 
 	require.NoError(t, db.Exec(`
-INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, 'xpla1asset0', 'xpla1asset1', 'xpla1lp')
-`, testChainID, testContract).Error)
+INSERT INTO tokens (chain_id, address, name, symbol, decimals) VALUES (?, ?, 'Abcd', 'ABCD', 18)
+`, testChainID, testTokenAddr).Error)
+
+	require.NoError(t, db.Exec(`
+INSERT INTO tokens (chain_id, address, name, symbol, decimals, verified) VALUES (?, 'axpla', 'XPLA', 'XPLA', 18, true)
+`, testChainID).Error)
+
+	require.NoError(t, db.Exec(`
+INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, 'xpla1asset0', 'xpla1asset1', 'xpla1lp1')
+`, testChainID, testPairContractAddr1).Error)
+
+	var pairID int64
+	row := db.Raw(`
+INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, 'axpla', ?, 'xpla1lp2') RETURNING id
+`, testChainID, testPairContractAddr2, testTokenAddr).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&pairID))
+
+	tsData = time.Now()
+	require.NoError(t, db.Exec(`
+INSERT INTO pair_stats_30m (
+    year_utc, month_utc, day_utc, hour_utc, minute_utc,
+    pair_id, chain_id,
+    volume0, volume1, volume0_in_price, volume1_in_price,
+    last_swap_price,
+    liquidity0, liquidity1, liquidity0_in_price, liquidity1_in_price,
+    commission0, commission1, commission0_in_price, commission1_in_price,
+    price_token,
+    tx_cnt, provider_cnt,
+    timestamp,
+    created_at, modified_at
+)
+VALUES (
+    ?, ?,?, ?, ?,
+    ?, ?,
+    100, 200, 123.45, 678.90,
+    1.23,
+    1000, 2000, 1111.11, 2222.22,
+    10, 20, 12.34, 56.78,
+    'ibc/ABCD',
+    5, 2,
+    ?,
+    ?, ?
+)
+`, tsData.Year(), tsData.Month(), tsData.Day(), tsData.Hour(), tsData.Minute(), pairID, testChainID, tsData.Unix(), tsData.Unix(), tsData.Unix()).Error)
 
 	return db
 }
@@ -36,6 +87,7 @@ func CleanupDB(t *testing.T, db *gorm.DB) {
 
 	require.NoError(t, db.Exec(`DELETE FROM pair_stats_30m WHERE pair_id IN (SELECT id FROM pair WHERE chain_id = ?)`, testChainID).Error)
 	require.NoError(t, db.Exec(`DELETE FROM pair WHERE chain_id = ?`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM tokens WHERE chain_id = ?`, testChainID).Error)
 
 	if sqlDB, err := db.DB(); err == nil {
 		_ = sqlDB.Close()
@@ -47,7 +99,7 @@ func TestRecentOf_NoDivisionByZero_WithPrevZeros(t *testing.T) {
 	defer CleanupDB(t, db)
 
 	d := &dashboard{DB: db, chainId: testChainID}
-	recent, err := d.RecentOf(Addr(testContract))
+	recent, err := d.RecentOf(Addr(testPairContractAddr1))
 	require.NoError(t, err)
 
 	assert.True(t, recent.PoolExists)
@@ -59,4 +111,94 @@ func TestRecentOf_NoDivisionByZero_WithPrevZeros(t *testing.T) {
 	assert.Equal(t, float32(0), recent.TvlChangeRate)
 	assert.Equal(t, float32(0), recent.Apr)
 	assert.Equal(t, float32(0), recent.AprChangeRate)
+}
+
+func TestTestTokenVolumes(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	addr := Addr(testTokenAddr)
+
+	t.Run("Month interval", func(t *testing.T) {
+		chart, err := d.TokenVolumes(addr, Month)
+		require.NoError(t, err)
+		require.NotNil(t, chart)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("Quarter interval", func(t *testing.T) {
+		chart, err := d.TokenVolumes(addr, Quarter)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("Year interval", func(t *testing.T) {
+		chart, err := d.TokenVolumes(addr, Year)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("All interval", func(t *testing.T) {
+		chart, err := d.TokenVolumes(addr, All)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+}
+
+func TestTestTokenTvls(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	addr := Addr(testTokenAddr)
+
+	t.Run("Month interval", func(t *testing.T) {
+		chart, err := d.TokenTvls(addr, Month)
+		require.NoError(t, err)
+		require.NotNil(t, chart)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("Quarter interval", func(t *testing.T) {
+		chart, err := d.TokenTvls(addr, Quarter)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("Year interval", func(t *testing.T) {
+		chart, err := d.TokenTvls(addr, Year)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
+
+	t.Run("Year interval", func(t *testing.T) {
+		chart, err := d.TokenTvls(addr, All)
+		require.NoError(t, err)
+		require.True(t, len(chart) > 0)
+
+		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
+		require.NoError(t, err)
+	})
 }

--- a/test_supplements/init.sql
+++ b/test_supplements/init.sql
@@ -13,7 +13,29 @@ CREATE UNIQUE INDEX pair_chain_id_contract_key ON pair (chain_id, contract);
 CREATE UNIQUE INDEX pair_chain_id_asset0_asset1_key ON pair (chain_id, asset0, asset1);
 CREATE UNIQUE INDEX pair_chain_id_lp_key ON pair (chain_id, lp);
 
-CREATE TABLE  pair_stats_30m (
+
+CREATE TABLE tokens (
+    id         BIGSERIAL                    PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    chain_id   TEXT                         NOT NULL,
+    address    TEXT                         NOT NULL,
+    protocol   TEXT,
+    symbol     TEXT,
+    name       TEXT,
+    decimals   SMALLINT,
+    icon       TEXT,
+    verified   BOOLEAN                      DEFAULT FALSE NOT NULL
+);
+
+CREATE INDEX idx_tokens_address ON tokens (address);
+CREATE INDEX idx_tokens_chain_id ON tokens (chain_id);
+CREATE UNIQUE INDEX idx_tokens_chain_id_address_key ON tokens (chain_id, address);
+CREATE INDEX idx_tokens_deleted_at ON tokens (deleted_at);
+
+
+CREATE TABLE pair_stats_30m (
     id                   BIGSERIAL                                                NOT NULL PRIMARY KEY,
     year_utc             SMALLINT                                                 NOT NULL,
     month_utc            SMALLINT                                                 NOT NULL,


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The token chart query was returning timestamp values as string (e.g., `"1757571243.000000"`), which caused parsing errors in Go when converting them into `int64`.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Fixed token chart query to cast result to `BIGINT`

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?