### PR TITLE
fix: fix concurrency issues in CoinGecko price fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         TEST_CONFIG: ${{ secrets.TEST_CONFIG }}
       run: |
         echo "$TEST_CONFIG" > config.yml
-        make test
+        make test-race
 
     - name: Build all
       run: make build-all

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ watch:
 test:
 	go test -short ./...
 
+.PHONY: test-race
+test-race:
+	go test -race -count=1 -short ./...
+
 # Run all benchmarks
 .PHONY: bench
 bench:

--- a/api/v1/service/coingecko/ticker.go
+++ b/api/v1/service/coingecko/ticker.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -31,11 +32,12 @@ const (
 type tickerService struct {
 	chainId string
 	*gorm.DB
+	mu           sync.RWMutex
 	cachedPrices [][priceInfoLength]float64
 }
 
 func NewTickerService(chainId string, db *gorm.DB) service.Getter[Ticker] {
-	return &tickerService{chainId, db, [][priceInfoLength]float64{}}
+	return &tickerService{chainId: chainId, DB: db}
 }
 
 // Get implements Getter
@@ -338,14 +340,20 @@ func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
 		return err
 	}
 
+	s.mu.Lock()
 	s.cachedPrices = decoded.Prices
+	s.mu.Unlock()
 
 	return nil
 }
 
 func (s *tickerService) price(targetTimestamp float64, force bool) float64 {
+	s.mu.RLock()
+	prices := s.cachedPrices
+	s.mu.RUnlock()
+
 	price := float64(0)
-	for _, p := range s.cachedPrices {
+	for _, p := range prices {
 		if p[priceTimestamp] > math.Trunc(targetTimestamp)*1_000 {
 			return price
 		}

--- a/api/v1/service/coingecko/ticker.go
+++ b/api/v1/service/coingecko/ticker.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const priceTokenId = "axlusdc"
@@ -30,14 +32,17 @@ const (
 )
 
 type tickerService struct {
-	chainId string
+	chainId    string
 	*gorm.DB
 	mu           sync.RWMutex
 	cachedPrices [][priceInfoLength]float64
+	sfGroup      singleflight.Group
+	httpClient   *http.Client
+	endpoint     string
 }
 
 func NewTickerService(chainId string, db *gorm.DB) service.Getter[Ticker] {
-	return &tickerService{chainId: chainId, DB: db}
+	return &tickerService{chainId: chainId, DB: db, endpoint: coinGeckoEndpoint}
 }
 
 // Get implements Getter
@@ -70,8 +75,9 @@ func (s *tickerService) Get(key string) (*Ticker, error) {
 	}
 
 	if p := s.price(ticker.Timestamp, false); p == 0 {
-		err := s.cachePriceInUsd(priceTokenId)
-		if err != nil {
+		if _, err, _ = s.sfGroup.Do(priceTokenId, func() (any, error) {
+			return nil, s.cachePriceInUsd(priceTokenId)
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -173,8 +179,9 @@ func (s *tickerService) GetAll() ([]Ticker, error) {
 	}
 
 	if p := s.price(latestTs, false); p == 0 {
-		err := s.cachePriceInUsd(priceTokenId)
-		if err != nil {
+		if _, err, _ = s.sfGroup.Do(priceTokenId, func() (any, error) {
+			return nil, s.cachePriceInUsd(priceTokenId)
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -301,7 +308,7 @@ func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
-	endpoint, err := url.Parse(coinGeckoEndpoint + priceCoinId + "/market_chart")
+	endpoint, err := url.Parse(s.endpoint + priceCoinId + "/market_chart")
 	if err != nil {
 		return err
 	}
@@ -316,7 +323,10 @@ func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
 		return err
 	}
 
-	client := http.Client{}
+	client := s.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
 	response, err := client.Do(request)
 	if err != nil {
 		return err

--- a/api/v1/service/coingecko/ticker_race_test.go
+++ b/api/v1/service/coingecko/ticker_race_test.go
@@ -1,0 +1,37 @@
+package coingecko
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestCachedPricesNoRace verifies that concurrent reads and writes to
+// cachedPrices do not trigger the race detector.
+func TestCachedPricesNoRace(t *testing.T) {
+	s := &tickerService{}
+
+	sample := [][priceInfoLength]float64{
+		{1_000_000, 1.0},
+		{2_000_000, 2.0},
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+
+		// writer: simulates cachePriceInUsd replacing the slice
+		go func() {
+			defer wg.Done()
+			s.mu.Lock()
+			s.cachedPrices = sample
+			s.mu.Unlock()
+		}()
+
+		// reader: simulates price() iterating the slice
+		go func() {
+			defer wg.Done()
+			_ = s.price(0, true)
+		}()
+	}
+	wg.Wait()
+}

--- a/api/v1/service/coingecko/ticker_singleflight_test.go
+++ b/api/v1/service/coingecko/ticker_singleflight_test.go
@@ -1,0 +1,74 @@
+package coingecko
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSingleflightDeduplicatesCoinGeckoRequests verifies that concurrent calls
+// to cachePriceInUsd via sfGroup.Do result in exactly one outbound HTTP request.
+func TestSingleflightDeduplicatesCoinGeckoRequests(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		time.Sleep(20 * time.Millisecond) // let goroutines pile up before responding
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"prices":[[1000000,1.0],[2000000,2.0]]}`)
+	}))
+	defer srv.Close()
+
+	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/"}
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.sfGroup.Do(priceTokenId, func() (any, error) { //nolint:errcheck
+				return nil, s.cachePriceInUsd(priceTokenId)
+			})
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), callCount.Load(), "singleflight should collapse concurrent fetches into one HTTP request")
+	assert.Equal(t, 2.0, s.price(3_000_000, true), "prices should be cached after fetch")
+}
+
+// TestSingleflightSecondBatchFetchesAgain verifies that after the in-flight
+// call completes, a subsequent call (new batch) does issue a new HTTP request.
+func TestSingleflightSecondBatchFetchesAgain(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"prices":[[1000000,1.0],[2000000,2.0]]}`)
+	}))
+	defer srv.Close()
+
+	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/"}
+
+	// first call
+	_, err, _ := s.sfGroup.Do(priceTokenId, func() (any, error) {
+		return nil, s.cachePriceInUsd(priceTokenId)
+	})
+	assert.NoError(t, err)
+
+	// second call — previous Do has already finished, so a new request goes out
+	_, err, _ = s.sfGroup.Do(priceTokenId, func() (any, error) {
+		return nil, s.cachePriceInUsd(priceTokenId)
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, int32(2), callCount.Load(), "each independent call should fetch once")
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`tickerService` caches CoinGecko price data in a slice (`cachedPrices`) that is read and written by concurrent goroutines. Two concurrency bugs existed:
1. The slice was accessed without any synchronization, causing a data race detectable by Go's race detector.
2. The check-then-fetch pattern was unguarded, so multiple goroutines could simultaneously observe a missing price and each fire an independent HTTP request to CoinGecko.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added `sync.RWMutex` to `tickerService` to protect `cachedPrices; price()` copies the slice header under a read lock and `cachePriceInUsd` assigns under a write lock
- Wraped both `cachePriceInUsd` call sites in `singleflight.Group.Do` so concurrent goroutines collapse into a single outbound HTTP request
- Added tc to verify the mutex under `-race` and the case that 20 callers produce one http request
- Added make test-race target and update CI to run tests with the race detector 

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?