### PR TITLE
fix: replace ibc address slash with a safe surrogate

### DIFF
--- a/api/v1/controller/dashboard/dashboard.go
+++ b/api/v1/controller/dashboard/dashboard.go
@@ -96,7 +96,7 @@ func (c *dashboardController) ChartByToken(ctx *gin.Context) {
 		duration = dashboard2.All
 	}
 
-	addr := dashboard2.Addr(ctx.Param("address"))
+	addr := dashboard2.Addr(httputil.DecodeAddressParam(ctx.Param("address")))
 	if len(addr) == 0 {
 		httputil.NewError(ctx, http.StatusBadRequest, errors.New("must provide token address"))
 		return
@@ -371,6 +371,7 @@ func (c *dashboardController) Token(ctx *gin.Context) {
 		httputil.NewError(ctx, http.StatusBadRequest, errors.New("invalid address address"))
 		return
 	}
+	address = httputil.DecodeAddressParam(address)
 
 	token, err := c.Dashboard.Token(dashboard2.Addr(address))
 	if err != nil {

--- a/api/v1/controller/token.go
+++ b/api/v1/controller/token.go
@@ -70,6 +70,7 @@ func (c *tokenController) Token(ctx *gin.Context) {
 	}
 
 	address = strings.TrimPrefix(address, "/")
+	address = httputil.DecodeAddressParam(address)
 	token, err := c.Get(address)
 	if err != nil {
 		c.logger.Warn(err)

--- a/pkg/httputil/address.go
+++ b/pkg/httputil/address.go
@@ -1,0 +1,12 @@
+package httputil
+
+import "strings"
+
+// DecodeAddressParam restores IBC token addresses that were encoded for
+// URL path segments. by replacing a leading "ibc-" prefix with "ibc/".
+func DecodeAddressParam(encoded string) string {
+	if strings.HasPrefix(encoded, "ibc-") {
+		return "ibc/" + encoded[len("ibc-"):]
+	}
+	return encoded
+}

--- a/pkg/httputil/address_test.go
+++ b/pkg/httputil/address_test.go
@@ -1,0 +1,24 @@
+package httputil
+
+import (
+	"testing"
+)
+
+func TestDecodeAddressParam(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"xpla1abc", "xpla1abc"},
+		{"ibc-ABCD1234", "ibc/ABCD1234"},
+		{"some-other-denom", "some-other-denom"},
+	}
+
+	for _, tc := range cases {
+		got := DecodeAddressParam(tc.input)
+		if got != tc.want {
+			t.Errorf("DecodeAddressParam(%q) = %q; want %q", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The service accepts token addresses directly in the request path (e.g. `/v1/dashboard/chart/tokens/:address`) and IBC token addresses include `/` (e.g. `ibc/...`).

Following the migration to GCP, the load balancer started normalizing or rejecting encoded path segments containing `%2F`, making it impossible to reliably pass such token addresses through the path.

As a result, a workaround was required to ensure compatibility with the current infrastructure constraints.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Replaced `/` with `-` as a surrogate delimiter for token addresses in path parameters (e.g. `ibc/...` to `ibc-...`)

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?