### PR TITLE
ci: add automated release workflow with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  changelog:
+    permissions:
+      contents: write
+      pull-requests: read
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          body_path: CHANGELOG.md
+          tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         id: git-cliff
         with:
           config: cliff.toml
-          args: --latest --strip all
+          args: --current --strip all
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to dezswap-api
+
+## Branching
+
+- Base all changes off `main`.
+- Use descriptive branch names: `feat/short-description`, `fix/short-description`.
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Each commit message must have a type prefix:
+
+| Prefix | When to use |
+|---|---|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `refactor:` | Code change that is not a feature or fix |
+| `perf:` | Performance improvement |
+| `docs:` | Documentation only |
+| `test:` | Adding or updating tests |
+| `chore:` | Maintenance (deps, tooling, config) |
+| `ci:` | CI/CD changes |
+
+`docs:`, `test:`, `chore:`, `ci:`, and `build:` commits are excluded from the changelog automatically.
+
+## Pull Requests
+
+1. Keep PRs focused — one concern per PR.
+2. Fill in the [PR template](.github/pull_request_template.md).
+3. All CI checks (lint, test, build) must pass before merging.
+
+## Development Setup
+
+```bash
+# Install dependencies
+go mod download
+
+# Config setup
+cp config.example.yml config.yml
+
+# Start DB, Redis, and app (indexer by default)
+make up
+APP_TYPE=api make up   # or start the API server
+```
+
+> The database schema depends on migrations from [cosmwasm-etl](https://github.com/dezswap/cosmwasm-etl). Run those first.
+
+```bash
+make api-migrate-up
+```
+
+## Code Quality
+
+```bash
+make fmt        # format
+make lint       # golangci-lint
+make test       # unit tests (-short)
+make test-race  # tests with race detector
+```
+
+All tests must pass with `make test-race`. Integration tests requiring a live DB are gated by the `-short` flag and run in CI only.
+
+## Generating Code
+
+```bash
+make generate   # regenerates ERC20 bindings via abigen
+```
+
+Run this after modifying any ABI files under `pkg/erc20/`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # dezswap-api
+
+Backend API and indexer service for [Dezswap](https://dezswap.io).
+
+## Overview
+
+This repository contains two independent binaries that share a PostgreSQL database:
+
+- **`indexer`** — background worker that periodically syncs token metadata, liquidity pool states, and verified token status from blockchains via gRPC.
+- **`api`** — Gin HTTP server exposing REST endpoints for the Dezswap frontend, plus CoinGecko and CoinMarketCap compatibility endpoints.
+
+## Prerequisites
+
+- Go 1.23+
+- Docker (for PostgreSQL and Redis)
+- [golangci-lint](https://golangci-lint.run/) (for linting)
+
+## Getting Started
+
+```bash
+# 1. Clone
+git clone https://github.com/dezswap/dezswap-api.git
+cd dezswap-api
+
+# 2. Configure
+cp config.example.yml config.yml
+# Edit config.yml with your chain and DB settings
+
+# 4. Build and run
+make api       # builds ./main for the API server
+make indexer   # builds ./main for the indexer
+```
+
+## Configuration
+
+Configuration is loaded from `config.yml` by default. Environment variables are supported using the `APP_` prefix with dots replaced by underscores (e.g., `APP_API_SERVER_PORT=8000`).
+
+Key sections in `config.yml`:
+
+| Section | Description |
+|---|---|
+| `indexer` | Chain ID, gRPC node endpoint, EVM RPC, source DB |
+| `api.server` | Host, port, CORS origins, Swagger toggle |
+| `api.db` | PostgreSQL connection |
+| `api.cache` | Redis or in-memory cache |
+| `log` | Log level and format |
+| `sentry` | Optional Sentry DSN for error tracking |
+
+See [`config.example.yml`](config.example.yml) for the full reference.
+
+### Database Migrations
+
+The database schema depends on migrations managed by [cosmwasm-etl](https://github.com/dezswap/cosmwasm-etl). Run those migrations first before applying the API-specific ones below.
+
+```bash
+make api-migrate-up
+make api-migrate-down
+make api-generate-migration
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,68 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} \
+  ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/dezswap/dezswap-api/commit/{{ commit.id }}))\
+  {% if commit.remote.pr_number %}[#{{ commit.remote.pr_number }}](https://github.com/dezswap/dezswap-api/pull/{{ commit.remote.pr_number }}){% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases %}\
+{% if release.version %}\
+{% if release.previous.version %}\
+[{{ release.version | trim_start_matches(pat="v") }}]: \
+  https://github.com/dezswap/dezswap-api/compare/{{ release.previous.version }}...{{ release.version }}
+{% else %}\
+[{{ release.version | trim_start_matches(pat="v") }}]: \
+  https://github.com/dezswap/dezswap-api/releases/tag/{{ release.version }}
+{% endif %}\
+{% else %}\
+[Unreleased]: https://github.com/dezswap/dezswap-api/compare/{{ release.previous.version }}...HEAD
+{% endif %}\
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^perf", group = "Changed" },
+  { message = "^revert", group = "Fixed" },
+  { message = "^docs", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^test", skip = true },
+  { message = "^build", skip = true },
+]
+
+filter_commits = true
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+[remote.github]
+owner = "dezswap"
+repo = "dezswap-api"


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The project had no automated release process or changelog. Every release required manually writing GitHub Release notes and tracking changes across PRs by hand.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- **`cliff.toml` + `.github/workflows/release.yml`:** On every `v*` tag push, `git-cliff` generates release notes from conventional commits and `softprops/action-gh-release` publishes the GitHub Release automatically.
- **`README.md`:** Clarified Getting Started flow; noted that the DB schema depends on `cosmwasm-etl` migrations.
- **`CONTRIBUTING.md`:** Added branching conventions, commit message guidelines (aligned with `cliff.toml` parsers), and development setup instructions.
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?