### PR TITLE
feat: add lazy eviction and background cleanup to in-memory cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run --rm -it --env-file=path/to/.env --name dezswap-api-app dezswap/dezswap-api-service
 
 ### BUILD
-FROM golang:1.23-alpine AS build
+FROM golang:1.25-alpine AS build
 ARG APP_TYPE=indexer
 ARG LIBWASMVM_VERSION=v2.2.4
 ARG APP_VERSION=dev

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains two independent binaries that share a PostgreSQL databa
 
 ## Prerequisites
 
-- Go 1.23+
+- Go 1.25+
 - Docker (for PostgreSQL and Redis)
 - [golangci-lint](https://golangci-lint.run/) (for linting)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	cache_redis "github.com/dezswap/dezswap-api/pkg/cache/redis"
@@ -23,22 +25,24 @@ import (
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	c := configs.New()
 	c.Log.ChainId = c.Api.Server.ChainId
-	cache := cacheStore(c.Api.Cache)
+	cache := cacheStore(ctx, c.Api.Cache)
 	db := dbCon(c.Api.DB)
 	api.RunServer(c, cache, db)
 }
 
 func dbCon(c configs.RdbConfig) *gorm.DB {
-
-    dbDsn := fmt.Sprintf(
-        "host=%s port=%s user=%s password=%s dbname=%s",
-        c.Host, c.Port, c.Username, c.Password, c.Database,
-    )
-    if c.SSLMode != "" {
-        dbDsn = fmt.Sprintf("%s sslmode=%s", dbDsn, c.SSLMode)
-    }
+	dbDsn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s",
+		c.Host, c.Port, c.Username, c.Password, c.Database,
+	)
+	if c.SSLMode != "" {
+		dbDsn = fmt.Sprintf("%s sslmode=%s", dbDsn, c.SSLMode)
+	}
 	writer := io.MultiWriter(os.Stdout)
 	db, err := gorm.Open(postgres.Open(dbDsn), &gorm.Config{
 		NowFunc: func() time.Time {
@@ -60,7 +64,7 @@ func dbCon(c configs.RdbConfig) *gorm.DB {
 	return db
 }
 
-func cacheStore(c configs.CacheConfig) cache.Cache {
+func cacheStore(ctx context.Context, c configs.CacheConfig) cache.Cache {
 	if c.RedisConfig.Host != "" {
 		option := redis.Options{
 			Addr:     fmt.Sprintf("%s:%s", c.RedisConfig.Host, c.RedisConfig.Port),
@@ -77,13 +81,15 @@ func cacheStore(c configs.CacheConfig) cache.Cache {
 		}
 
 		client := redis.NewClient(&option)
-		if err := client.Ping(context.Background()).Err(); err != nil {
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if err := client.Ping(pingCtx).Err(); err != nil {
 			panic(err)
 		}
 		return cache_redis.New(cache.NewByteCodec(), client)
 	}
 	if c.MemoryCache {
-		return memory.NewMemoryCache(cache.NewByteCodec())
+		return memory.NewMemoryCache(ctx, cache.NewByteCodec())
 	}
 
 	return nil

--- a/pkg/cache/memory/memory-cache.go
+++ b/pkg/cache/memory/memory-cache.go
@@ -1,12 +1,15 @@
 package memory
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/dezswap/dezswap-api/pkg/cache"
 	"github.com/pkg/errors"
 )
+
+const defaultCleanupInterval = time.Minute
 
 type item struct {
 	Value    interface{}
@@ -19,12 +22,14 @@ type memoryCacheImpl struct {
 	store map[string]item
 }
 
-func NewMemoryCache(codec cache.Codable) cache.Cache {
-	return &memoryCacheImpl{
+func NewMemoryCache(ctx context.Context, codec cache.Codable) cache.Cache {
+	c := &memoryCacheImpl{
 		codec:   codec,
 		RWMutex: &sync.RWMutex{},
 		store:   make(map[string]item),
 	}
+	go c.startCleanup(ctx, defaultCleanupInterval)
+	return c
 }
 
 func (r *memoryCacheImpl) Ping() error {
@@ -33,23 +38,28 @@ func (r *memoryCacheImpl) Ping() error {
 
 func (c *memoryCacheImpl) Get(key string, dest interface{}) error {
 	c.RLock()
-	defer c.RUnlock()
-
 	item, found := c.store[key]
+	c.RUnlock()
+
 	if !found {
 		return cache.ErrCacheMiss
 	}
-
 	if item.ExpireAt != nil && time.Now().After(*item.ExpireAt) {
-		delete(c.store, key)
+		c.evictIfExpired(key)
 		return cache.ErrCacheMiss
 	}
-
 	if err := c.codec.Decode(item.Value.([]byte), dest); err != nil {
 		return errors.Wrap(err, "memoryCacheImpl.Get")
 	}
-
 	return nil
+}
+
+func (c *memoryCacheImpl) evictIfExpired(key string) {
+	c.Lock()
+	defer c.Unlock()
+	if v, ok := c.store[key]; ok && v.ExpireAt != nil && time.Now().After(*v.ExpireAt) {
+		delete(c.store, key)
+	}
 }
 
 func (c *memoryCacheImpl) Set(key string, value interface{}, ttl time.Duration) error {
@@ -78,4 +88,41 @@ func (c *memoryCacheImpl) Delete(key string) error {
 
 	delete(c.store, key)
 	return nil
+}
+
+func (c *memoryCacheImpl) startCleanup(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.deleteExpired()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *memoryCacheImpl) deleteExpired() {
+	now := time.Now()
+	c.RLock()
+	var expired []string
+	for key, item := range c.store {
+		if item.ExpireAt != nil && now.After(*item.ExpireAt) {
+			expired = append(expired, key)
+		}
+	}
+	c.RUnlock()
+
+	if len(expired) == 0 {
+		return
+	}
+
+	c.Lock()
+	for _, key := range expired {
+		if v, ok := c.store[key]; ok && v.ExpireAt != nil && time.Now().After(*v.ExpireAt) {
+			delete(c.store, key)
+		}
+	}
+	c.Unlock()
 }

--- a/pkg/cache/memory/memory-cache_test.go
+++ b/pkg/cache/memory/memory-cache_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -29,27 +30,25 @@ func Test_cache(t *testing.T) {
 	tcs := []testCase{
 		// find key
 		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, 0, "garbageValue", "value"},
-		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, time.Second, "garbageValue", "value"},
-		{setUpItem{"test", "value", time.Second * 2}, time.Second, "garbageValue", "value"},
-		{setUpItem{"test", "value", time.Second}, time.Second * 2, "", ""},
-		{setUpItem{"test", "value", time.Second}, time.Second * 2, "", ""},
+		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, time.Millisecond * 50, "garbageValue", "value"},
+		{setUpItem{"test", "value", time.Millisecond * 100}, time.Millisecond * 50, "garbageValue", "value"},
+		{setUpItem{"test", "value", time.Millisecond * 50}, time.Millisecond * 150, "", ""},
+		{setUpItem{"test", "value", time.Millisecond * 50}, time.Millisecond * 150, "", ""},
 	}
 
-	assert := assert.New(t)
-
-	tcTester := func(id int, t testCase) {
-		c := NewMemoryCache(cache.NewByteCodec())
-		setUp(t.item, c)
+	tcTester := func(id int, tc testCase) {
+		c := NewMemoryCache(context.Background(), cache.NewByteCodec())
+		setUp(tc.item, c)
 		fmt.Printf("test case %d\n", id)
-		time.Sleep(t.wait)
+		time.Sleep(tc.wait)
 
-		err := c.Get(t.item.key, &t.destination)
-		if t.expected == "" {
-			assert.Error(err)
+		err := c.Get(tc.item.key, &tc.destination)
+		if tc.expected == "" {
+			assert.Error(t, err)
 		} else {
-			assert.NoError(err)
+			assert.NoError(t, err)
 		}
-		assert.Equal(t.expected, t.destination)
+		assert.Equal(t, tc.expected, tc.destination)
 	}
 
 	wg := sync.WaitGroup{}
@@ -62,4 +61,31 @@ func Test_cache(t *testing.T) {
 		}(id, tc)
 	}
 	wg.Wait()
+}
+
+func Test_deleteExpired(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewMemoryCache(ctx, cache.NewByteCodec()).(*memoryCacheImpl)
+
+	// Set one item that expires soon and one that does not
+	c.Set("expires", "value", time.Millisecond*10)
+	c.Set("permanent", "value", cache.CacheLifeTimeNeverExpired)
+
+	// Wait for the item to expire
+	time.Sleep(time.Millisecond * 20)
+
+	// Manually trigger cleanup
+	c.deleteExpired()
+
+	c.RLock()
+	_, hasExpired := c.store["expires"]
+	_, hasPermanent := c.store["permanent"]
+	c.RUnlock()
+
+	assert.False(hasExpired, "expired key should have been removed")
+	assert.True(hasPermanent, "permanent key should remain")
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The server was crashing with: `fatal error: concurrent map writes`
The root cause was in `Get()`: when a key was found to be expired, it called `delete(c.store, key)` while holding only an RLock. Since a read lock permits multiple concurrent holders, multiple goroutines could simultaneously hit the same expired key and each attempt a map write, causing the fatal error.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- `Get()`: fix concurrent map writes: Replaced the in-place delete under RLock with `evictIfExpired()`, which properly acquires a write lock and re-checks expiry before deleting (prevents TOCTOU races).
- Background cleanup for orphan keys: Added `startCleanup` goroutine (1-minute interval) to evict keys that are set but never read. Scans under `RLock`, deletes under `Lock` to minimize contention.                                                                                                
- Context-aware shutdown: `NewMemoryCache` now accepts `context.Context`; the cleanup goroutine exits on cancellation. `cmd/api/main.go` passes a `signal.NotifyContext` (`SIGINT`/`SIGTERM`) to ensure clean shutdown.                                                                                  
- Redis ping timeout: Replaced `context.Background()` with `context.WithTimeout(ctx, 5s)`.
- Test improvements: Reduced wait times from seconds to milliseconds; added `Test_deleteExpired` to verify cleanup logic directly.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?