### PR TITLE
fix: SQL injection in inactive pool queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run --rm -it --env-file=path/to/.env --name dezswap-api-app dezswap/dezswap-api-service
 
 ### BUILD
-FROM golang:1.23-alpine AS build
+FROM golang:1.25-alpine AS build
 ARG APP_TYPE=indexer
 ARG LIBWASMVM_VERSION=v2.2.4
 ARG APP_VERSION=dev

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains two independent binaries that share a PostgreSQL databa
 
 ## Prerequisites
 
-- Go 1.23+
+- Go 1.25+
 - Docker (for PostgreSQL and Redis)
 - [golangci-lint](https://golangci-lint.run/) (for linting)
 

--- a/api/v1/service/coingecko/ticker.go
+++ b/api/v1/service/coingecko/ticker.go
@@ -2,12 +2,7 @@ package coingecko
 
 import (
 	"context"
-	cmath "cosmossdk.io/math"
 	"encoding/json"
-	"github.com/dezswap/dezswap-api/api/v1/service"
-	"github.com/dezswap/dezswap-api/pkg"
-	"github.com/pkg/errors"
-	"gorm.io/gorm"
 	"math"
 	"net/http"
 	"net/url"
@@ -15,6 +10,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	cmath "cosmossdk.io/math"
+	"github.com/dezswap/dezswap-api/api/v1/service"
+	"github.com/dezswap/dezswap-api/pkg"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"golang.org/x/sync/singleflight"
 )
@@ -32,7 +33,7 @@ const (
 )
 
 type tickerService struct {
-	chainId    string
+	chainId string
 	*gorm.DB
 	mu           sync.RWMutex
 	cachedPrices [][priceInfoLength]float64
@@ -61,7 +62,7 @@ func (s *tickerService) Get(key string) (*Ticker, error) {
 	if len(tickers) > 0 {
 		ticker = &tickers[len(tickers)-1]
 		if ticker.LastPrice == "" {
-			price, err := s.lastSwapPrice(ticker.PoolId)
+			price, err := s.lastSwapPriceFromInactive(ticker.PoolId)
 			if err != nil {
 				return nil, errors.Wrap(err, "tickerService.Get")
 			}
@@ -91,9 +92,10 @@ func (s *tickerService) Get(key string) (*Ticker, error) {
 	return ticker, nil
 }
 
-func (s *tickerService) lastSwapPrice(poolId string) (string, error) {
-	cond := "p.contract = '" + poolId + "'"
-	inactiveTickers, err := s.inactivePools(cond)
+// lastSwapPriceFromInactive returns the most recent swap price
+// for a pool that has no activity in the recent window.
+func (s *tickerService) lastSwapPriceFromInactive(poolId string) (string, error) {
+	inactiveTickers, err := s.inactivePool(poolId)
 	if err != nil {
 		return "", err
 	}
@@ -154,11 +156,7 @@ func (s *tickerService) GetAll() ([]Ticker, error) {
 		}
 	}
 
-	var cond string
-	if len(activePoolIds) > 0 {
-		cond = "p.contract not in ('" + strings.Join(activePoolIds, "','") + "')"
-	}
-	inactiveTickers, err := s.inactivePools(cond)
+	inactiveTickers, err := s.inactivePools(activePoolIds)
 	if err != nil {
 		return nil, errors.Wrap(err, "tickerService.GetAll")
 	}
@@ -259,8 +257,22 @@ where ps.chain_id = ?
 	return tickers, nil
 }
 
-func (s *tickerService) inactivePools(cond string) ([]Ticker, error) {
-	query := `
+// inactivePool returns ticker data for a single inactive pool by contract address.
+func (s *tickerService) inactivePool(contractId string) ([]Ticker, error) {
+	return s.queryInactivePools(" and p.contract = ?", contractId)
+}
+
+// inactivePools returns ticker data for all inactive pools, excluding the given pool IDs.
+func (s *tickerService) inactivePools(excludePoolIds []string) ([]Ticker, error) {
+	if len(excludePoolIds) > 0 {
+		return s.queryInactivePools(" and p.contract not in ?", excludePoolIds)
+	}
+	return s.queryInactivePools("", nil)
+}
+
+// queryInactivePools runs the pair_stats_30m base query with an optional extra condition and arg.
+func (s *tickerService) queryInactivePools(cond string, arg any) ([]Ticker, error) {
+	const query = `
 select p.asset0 base_currency,
        p.asset1 target_currency,
        '0' base_volume,
@@ -269,25 +281,26 @@ select p.asset0 base_currency,
        t0.decimals base_decimals,
        t1.decimals target_decimals,
        liquidity0_in_price base_liquidity_in_price,
-       p.contract pool_id, 
+       p.contract pool_id,
        extract(epoch from now()) * 1000 as timestamp
 from pair_stats_30m ps
 	join (select pair_id, max(timestamp) latest_timestamp
 		from pair_stats_30m
-		group by pair_id) t on ps.pair_id = t.pair_id and ps.timestamp = t.latest_timestamp 
+		group by pair_id) t on ps.pair_id = t.pair_id and ps.timestamp = t.latest_timestamp
 	join pair p on ps.pair_id = p.id
 	join tokens t0 on p.chain_id = t0.chain_id and p.asset0 = t0.address
 	join tokens t1 on p.chain_id = t1.chain_id and p.asset1 = t1.address
 where p.chain_id = ?
 `
-
-	if cond != "" {
-		query += " and " + cond
-	}
-
 	var tickers []Ticker
-	if tx := s.Raw(query, s.chainId).Find(&tickers); tx.Error != nil {
-		return nil, errors.Wrap(tx.Error, "TickerService.inactivePools")
+	var tx *gorm.DB
+	if cond != "" {
+		tx = s.Raw(query+cond, s.chainId, arg).Find(&tickers)
+	} else {
+		tx = s.Raw(query, s.chainId).Find(&tickers)
+	}
+	if tx.Error != nil {
+		return nil, errors.Wrap(tx.Error, "TickerService.queryInactivePools")
 	}
 
 	return tickers, nil

--- a/api/v1/service/coingecko/ticker_test.go
+++ b/api/v1/service/coingecko/ticker_test.go
@@ -1,0 +1,94 @@
+package coingecko
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func setupTickerServiceWithMock(t *testing.T) (*tickerService, sqlmock.Sqlmock, func() error) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: sqlDB}),
+		&gorm.Config{},
+	)
+	require.NoError(t, err)
+
+	svc := &tickerService{
+		chainId: "test-chain",
+		DB:      gormDB,
+	}
+
+	return svc, mock, sqlDB.Close
+}
+
+var inactivePoolColumns = []string{
+	"base_currency", "target_currency",
+	"base_volume", "target_volume", "last_price",
+	"base_decimals", "target_decimals",
+	"base_liquidity_in_price", "pool_id", "timestamp",
+}
+
+// TestQueryInactivePools_ByContractId verifies that inactivePool passes the
+// contract address as a bound parameter instead of interpolating it into SQL.
+func TestQueryInactivePools_ByContractId(t *testing.T) {
+	svc, mock, close := setupTickerServiceWithMock(t)
+	defer close()
+
+	mock.ExpectQuery(`from pair_stats_30m`).
+		WithArgs("test-chain", "xpla1pool123").
+		WillReturnRows(
+			sqlmock.NewRows(inactivePoolColumns).
+				AddRow("tokenA", "tokenB", "0", "0", "1.5", 6, 6, "100.0", "xpla1pool123", 1000000.0),
+		)
+
+	tickers, err := svc.inactivePool("xpla1pool123")
+	require.NoError(t, err)
+	require.Len(t, tickers, 1)
+	require.Equal(t, "xpla1pool123", tickers[0].PoolId)
+	require.Equal(t, "1.5", tickers[0].LastPrice)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryInactivePools_WithExclusion verifies that inactivePools passes
+// excluded pool IDs as bound parameters instead of interpolating them into SQL.
+func TestQueryInactivePools_WithExclusion(t *testing.T) {
+	svc, mock, close := setupTickerServiceWithMock(t)
+	defer close()
+
+	mock.ExpectQuery(`from pair_stats_30m`).
+		WithArgs("test-chain", "xpla1active1", "xpla1active2").
+		WillReturnRows(
+			sqlmock.NewRows(inactivePoolColumns).
+				AddRow("tokenA", "tokenB", "0", "0", "2.0", 6, 6, "200.0", "xpla1inactive", 1000000.0),
+		)
+
+	tickers, err := svc.inactivePools([]string{"xpla1active1", "xpla1active2"})
+	require.NoError(t, err)
+	require.Len(t, tickers, 1)
+	require.Equal(t, "xpla1inactive", tickers[0].PoolId)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryInactivePools_NoFilter verifies that inactivePools with no exclusions
+// runs the base query with only the chain ID as a bound parameter.
+func TestQueryInactivePools_NoFilter(t *testing.T) {
+	svc, mock, close := setupTickerServiceWithMock(t)
+	defer close()
+
+	mock.ExpectQuery(`from pair_stats_30m`).
+		WithArgs("test-chain").
+		WillReturnRows(sqlmock.NewRows(inactivePoolColumns))
+
+	tickers, err := svc.inactivePools(nil)
+	require.NoError(t, err)
+	require.Empty(t, tickers)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/api/v1/service/coinmarketcap/ticker.go
+++ b/api/v1/service/coinmarketcap/ticker.go
@@ -232,12 +232,14 @@ from pair_stats_30m ps
 	join tokens t1 on p.chain_id = t1.chain_id and p.asset1 = t1.address
 where p.chain_id = ?
 `
-	if len(activePoolIds) > 0 {
-		query += " and p.contract not in ('" + strings.Join(activePoolIds, "','") + "')"
-	}
-
 	tickers := []Ticker{}
-	if tx := s.Raw(query, s.chainId).Find(&tickers); tx.Error != nil {
+	var tx *gorm.DB
+	if len(activePoolIds) > 0 {
+		tx = s.Raw(query+" and p.contract not in ?", s.chainId, activePoolIds).Find(&tickers)
+	} else {
+		tx = s.Raw(query, s.chainId).Find(&tickers)
+	}
+	if tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "TickerService.inactivePools")
 	}
 

--- a/api/v1/service/coinmarketcap/ticker_test.go
+++ b/api/v1/service/coinmarketcap/ticker_test.go
@@ -1,0 +1,73 @@
+package coinmarketcap
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func setupTickerServiceWithMock(t *testing.T) (*tickerService, sqlmock.Sqlmock, func() error) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: sqlDB}),
+		&gorm.Config{},
+	)
+	require.NoError(t, err)
+
+	svc := &tickerService{
+		chainId: "test-chain",
+		DB:      gormDB,
+	}
+
+	return svc, mock, sqlDB.Close
+}
+
+var inactivePoolColumns = []string{
+	"base_address", "base_name", "base_symbol",
+	"quote_address", "quote_name", "quote_symbol",
+	"base_volume", "quote_volume", "last_price",
+	"quote_decimals", "base_decimals", "timestamp",
+}
+
+// TestInactivePools_ExcludesActivePoolIds verifies that active pool IDs are
+// passed as bound parameters instead of being interpolated into SQL.
+func TestInactivePools_ExcludesActivePoolIds(t *testing.T) {
+	svc, mock, close := setupTickerServiceWithMock(t)
+	defer close()
+
+	mock.ExpectQuery(`from pair_stats_30m`).
+		WithArgs("test-chain", "xpla1active1", "xpla1active2").
+		WillReturnRows(
+			sqlmock.NewRows(inactivePoolColumns).
+				AddRow("addrA", "TokenA", "TKA", "addrB", "TokenB", "TKB", "0", "0", "1.0", 6, 6, 1000000.0),
+		)
+
+	tickers, err := svc.inactivePools([]string{"xpla1active1", "xpla1active2"})
+	require.NoError(t, err)
+	require.Len(t, tickers, 1)
+	require.Equal(t, "1.0", tickers[0].LastPrice)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestInactivePools_ReturnsAllWhenNoActiveIds verifies that passing no active
+// pool IDs runs the base query with only the chain ID bound.
+func TestInactivePools_ReturnsAllWhenNoActiveIds(t *testing.T) {
+	svc, mock, close := setupTickerServiceWithMock(t)
+	defer close()
+
+	mock.ExpectQuery(`from pair_stats_30m`).
+		WithArgs("test-chain").
+		WillReturnRows(sqlmock.NewRows(inactivePoolColumns))
+
+	tickers, err := svc.inactivePools(nil)
+	require.NoError(t, err)
+	require.Empty(t, tickers)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	cache_redis "github.com/dezswap/dezswap-api/pkg/cache/redis"
@@ -23,22 +25,24 @@ import (
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	c := configs.New()
 	c.Log.ChainId = c.Api.Server.ChainId
-	cache := cacheStore(c.Api.Cache)
+	cache := cacheStore(ctx, c.Api.Cache)
 	db := dbCon(c.Api.DB)
 	api.RunServer(c, cache, db)
 }
 
 func dbCon(c configs.RdbConfig) *gorm.DB {
-
-    dbDsn := fmt.Sprintf(
-        "host=%s port=%s user=%s password=%s dbname=%s",
-        c.Host, c.Port, c.Username, c.Password, c.Database,
-    )
-    if c.SSLMode != "" {
-        dbDsn = fmt.Sprintf("%s sslmode=%s", dbDsn, c.SSLMode)
-    }
+	dbDsn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s",
+		c.Host, c.Port, c.Username, c.Password, c.Database,
+	)
+	if c.SSLMode != "" {
+		dbDsn = fmt.Sprintf("%s sslmode=%s", dbDsn, c.SSLMode)
+	}
 	writer := io.MultiWriter(os.Stdout)
 	db, err := gorm.Open(postgres.Open(dbDsn), &gorm.Config{
 		NowFunc: func() time.Time {
@@ -60,7 +64,7 @@ func dbCon(c configs.RdbConfig) *gorm.DB {
 	return db
 }
 
-func cacheStore(c configs.CacheConfig) cache.Cache {
+func cacheStore(ctx context.Context, c configs.CacheConfig) cache.Cache {
 	if c.RedisConfig.Host != "" {
 		option := redis.Options{
 			Addr:     fmt.Sprintf("%s:%s", c.RedisConfig.Host, c.RedisConfig.Port),
@@ -77,13 +81,15 @@ func cacheStore(c configs.CacheConfig) cache.Cache {
 		}
 
 		client := redis.NewClient(&option)
-		if err := client.Ping(context.Background()).Err(); err != nil {
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if err := client.Ping(pingCtx).Err(); err != nil {
 			panic(err)
 		}
 		return cache_redis.New(cache.NewByteCodec(), client)
 	}
 	if c.MemoryCache {
-		return memory.NewMemoryCache(cache.NewByteCodec())
+		return memory.NewMemoryCache(ctx, cache.NewByteCodec())
 	}
 
 	return nil

--- a/pkg/cache/memory/memory-cache.go
+++ b/pkg/cache/memory/memory-cache.go
@@ -1,12 +1,15 @@
 package memory
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/dezswap/dezswap-api/pkg/cache"
 	"github.com/pkg/errors"
 )
+
+const defaultCleanupInterval = time.Minute
 
 type item struct {
 	Value    interface{}
@@ -19,12 +22,14 @@ type memoryCacheImpl struct {
 	store map[string]item
 }
 
-func NewMemoryCache(codec cache.Codable) cache.Cache {
-	return &memoryCacheImpl{
+func NewMemoryCache(ctx context.Context, codec cache.Codable) cache.Cache {
+	c := &memoryCacheImpl{
 		codec:   codec,
 		RWMutex: &sync.RWMutex{},
 		store:   make(map[string]item),
 	}
+	go c.startCleanup(ctx, defaultCleanupInterval)
+	return c
 }
 
 func (r *memoryCacheImpl) Ping() error {
@@ -33,23 +38,28 @@ func (r *memoryCacheImpl) Ping() error {
 
 func (c *memoryCacheImpl) Get(key string, dest interface{}) error {
 	c.RLock()
-	defer c.RUnlock()
-
 	item, found := c.store[key]
+	c.RUnlock()
+
 	if !found {
 		return cache.ErrCacheMiss
 	}
-
 	if item.ExpireAt != nil && time.Now().After(*item.ExpireAt) {
-		delete(c.store, key)
+		c.evictIfExpired(key)
 		return cache.ErrCacheMiss
 	}
-
 	if err := c.codec.Decode(item.Value.([]byte), dest); err != nil {
 		return errors.Wrap(err, "memoryCacheImpl.Get")
 	}
-
 	return nil
+}
+
+func (c *memoryCacheImpl) evictIfExpired(key string) {
+	c.Lock()
+	defer c.Unlock()
+	if v, ok := c.store[key]; ok && v.ExpireAt != nil && time.Now().After(*v.ExpireAt) {
+		delete(c.store, key)
+	}
 }
 
 func (c *memoryCacheImpl) Set(key string, value interface{}, ttl time.Duration) error {
@@ -78,4 +88,41 @@ func (c *memoryCacheImpl) Delete(key string) error {
 
 	delete(c.store, key)
 	return nil
+}
+
+func (c *memoryCacheImpl) startCleanup(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.deleteExpired()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *memoryCacheImpl) deleteExpired() {
+	now := time.Now()
+	c.RLock()
+	var expired []string
+	for key, item := range c.store {
+		if item.ExpireAt != nil && now.After(*item.ExpireAt) {
+			expired = append(expired, key)
+		}
+	}
+	c.RUnlock()
+
+	if len(expired) == 0 {
+		return
+	}
+
+	c.Lock()
+	for _, key := range expired {
+		if v, ok := c.store[key]; ok && v.ExpireAt != nil && time.Now().After(*v.ExpireAt) {
+			delete(c.store, key)
+		}
+	}
+	c.Unlock()
 }

--- a/pkg/cache/memory/memory-cache_test.go
+++ b/pkg/cache/memory/memory-cache_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -29,27 +30,25 @@ func Test_cache(t *testing.T) {
 	tcs := []testCase{
 		// find key
 		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, 0, "garbageValue", "value"},
-		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, time.Second, "garbageValue", "value"},
-		{setUpItem{"test", "value", time.Second * 2}, time.Second, "garbageValue", "value"},
-		{setUpItem{"test", "value", time.Second}, time.Second * 2, "", ""},
-		{setUpItem{"test", "value", time.Second}, time.Second * 2, "", ""},
+		{setUpItem{"test", "value", cache.CacheLifeTimeNeverExpired}, time.Millisecond * 50, "garbageValue", "value"},
+		{setUpItem{"test", "value", time.Millisecond * 100}, time.Millisecond * 50, "garbageValue", "value"},
+		{setUpItem{"test", "value", time.Millisecond * 50}, time.Millisecond * 150, "", ""},
+		{setUpItem{"test", "value", time.Millisecond * 50}, time.Millisecond * 150, "", ""},
 	}
 
-	assert := assert.New(t)
-
-	tcTester := func(id int, t testCase) {
-		c := NewMemoryCache(cache.NewByteCodec())
-		setUp(t.item, c)
+	tcTester := func(id int, tc testCase) {
+		c := NewMemoryCache(context.Background(), cache.NewByteCodec())
+		setUp(tc.item, c)
 		fmt.Printf("test case %d\n", id)
-		time.Sleep(t.wait)
+		time.Sleep(tc.wait)
 
-		err := c.Get(t.item.key, &t.destination)
-		if t.expected == "" {
-			assert.Error(err)
+		err := c.Get(tc.item.key, &tc.destination)
+		if tc.expected == "" {
+			assert.Error(t, err)
 		} else {
-			assert.NoError(err)
+			assert.NoError(t, err)
 		}
-		assert.Equal(t.expected, t.destination)
+		assert.Equal(t, tc.expected, tc.destination)
 	}
 
 	wg := sync.WaitGroup{}
@@ -62,4 +61,31 @@ func Test_cache(t *testing.T) {
 		}(id, tc)
 	}
 	wg.Wait()
+}
+
+func Test_deleteExpired(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewMemoryCache(ctx, cache.NewByteCodec()).(*memoryCacheImpl)
+
+	// Set one item that expires soon and one that does not
+	c.Set("expires", "value", time.Millisecond*10)
+	c.Set("permanent", "value", cache.CacheLifeTimeNeverExpired)
+
+	// Wait for the item to expire
+	time.Sleep(time.Millisecond * 20)
+
+	// Manually trigger cleanup
+	c.deleteExpired()
+
+	c.RLock()
+	_, hasExpired := c.store["expires"]
+	_, hasPermanent := c.store["permanent"]
+	c.RUnlock()
+
+	assert.False(hasExpired, "expired key should have been removed")
+	assert.True(hasPermanent, "permanent key should remain")
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 The CoinGecko and CoinMarketCap ticker services both queried `pair_stats_30m` for inactive pools using string interpolation to build `WHERE` clauses. Passing pool contract addresses and chain IDs directly into raw SQL strings is a SQL injection risk. 

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Refactored the three `inactivePool` methods in coingecko into a single `queryInactivePools(cond, arg)` helper that passes user-controlled values as GORM bound parameters instead of string-interpolating them                                                           
- Same pattern applied to `inactivePools` in coinmarketcap — pool IDs passed via `?` placeholder

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?