### PR TITLE
feat: wire CoinGecko API key via config

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -56,7 +56,7 @@ func RunServer(c configs.Config, cache cache.Cache, db *gorm.DB) {
 	app.setMiddlewares(cache)
 
 	v1Router := app.engine.Group(ApiVersion)
-	v1.RegisterRoutes(v1Router, serverConfig.ChainId, AppVersion, app.NetworkMetadata, db, cache, app.logger)
+	v1.RegisterRoutes(v1Router, serverConfig.ChainId, serverConfig.CoinGeckoApiKey, AppVersion, app.NetworkMetadata, db, cache, app.logger)
 
 	if c.Sentry.DSN != "" {
 		if err := app.configureReporter(c.Sentry.DSN, serverConfig.ChainId, map[string]string{

--- a/api/v1/router.go
+++ b/api/v1/router.go
@@ -22,7 +22,7 @@ import (
 )
 
 // RegisterRoutes sets up v1 API endpoints
-func RegisterRoutes(rg *gin.RouterGroup, chainId string, version string, networkMetadata pkg.NetworkMetadata, db *gorm.DB, cache cache.Cache, logger logging.Logger) {
+func RegisterRoutes(rg *gin.RouterGroup, chainId string, coinGeckoApiKey string, version string, networkMetadata pkg.NetworkMetadata, db *gorm.DB, cache cache.Cache, logger logging.Logger) {
 	statusService := service.NewStatusService(db, cache)
 	pairService := service.NewPairService(chainId, db)
 	poolService := service.NewPoolService(chainId, db)
@@ -38,7 +38,7 @@ func RegisterRoutes(rg *gin.RouterGroup, chainId string, version string, network
 	// CoinGecko endpoint
 	r := rg.Group("/coingecko")
 	coinGeckoPairService := cgs.NewPairService(chainId, db)
-	coinGeckoTickerService := cgs.NewTickerService(chainId, db)
+	coinGeckoTickerService := cgs.NewTickerService(chainId, db, coinGeckoApiKey)
 
 	coingecko.InitPairController(coinGeckoPairService, r, logger)
 	coingecko.InitTickerController(coinGeckoTickerService, r, logger)

--- a/api/v1/service/coingecko/ticker.go
+++ b/api/v1/service/coingecko/ticker.go
@@ -23,6 +23,7 @@ import (
 const priceTokenId = "axlusdc"
 const coinGeckoEndpoint = "https://api.coingecko.com/api/v3/coins/"
 const queryTimeout = 10 * time.Second
+const priceCacheTTL = 24 * time.Hour
 
 type priceInfo int
 
@@ -37,13 +38,20 @@ type tickerService struct {
 	*gorm.DB
 	mu           sync.RWMutex
 	cachedPrices [][priceInfoLength]float64
+	cacheExpiry  time.Time
 	sfGroup      singleflight.Group
 	httpClient   *http.Client
 	endpoint     string
+	apiKey       string
 }
 
-func NewTickerService(chainId string, db *gorm.DB) service.Getter[Ticker] {
-	return &tickerService{chainId: chainId, DB: db, endpoint: coinGeckoEndpoint}
+func NewTickerService(chainId string, db *gorm.DB, apiKey string) service.Getter[Ticker] {
+	s := &tickerService{chainId: chainId, DB: db, endpoint: coinGeckoEndpoint, apiKey: apiKey}
+	if apiKey == "" {
+		s.cachedPrices = [][priceInfoLength]float64{{0, 1.0}, {math.MaxFloat64, 1.0}}
+		s.cacheExpiry = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+	return s
 }
 
 // Get implements Getter
@@ -316,11 +324,21 @@ func (s *tickerService) liquidityInUsd(ticker Ticker) (string, error) {
 	return strconv.FormatFloat(baseLiquidityInPrice*priceTokenInUsd, 'f', -1, 64), nil
 }
 
-// TODO: fixed endpoint and arguments
+// cachePriceInUsd fetches the 24-hour price history of priceCoinId from the
+// CoinGecko market_chart endpoint and stores it in cachedPrices. It is a
+// no-op if the cache has not yet expired.
 func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
+	s.mu.RLock()
+	expiry := s.cacheExpiry
+	s.mu.RUnlock()
+	if time.Now().Before(expiry) {
+		return nil // still within TTL
+	}
+
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
+	// TODO: fixed endpoint and arguments
 	endpoint, err := url.Parse(s.endpoint + priceCoinId + "/market_chart")
 	if err != nil {
 		return err
@@ -335,6 +353,7 @@ func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
 	if err != nil {
 		return err
 	}
+	request.Header.Set("x-cg-demo-api-key", s.apiKey)
 
 	client := s.httpClient
 	if client == nil {
@@ -365,11 +384,15 @@ func (s *tickerService) cachePriceInUsd(priceCoinId string) error {
 
 	s.mu.Lock()
 	s.cachedPrices = decoded.Prices
+	s.cacheExpiry = time.Now().Add(priceCacheTTL)
 	s.mu.Unlock()
 
 	return nil
 }
 
+// price returns the USD price of the price token at the given timestamp.
+// force=true returns the last seen price while force=false returns 0
+// (signalling the caller to trigger a cache refresh).
 func (s *tickerService) price(targetTimestamp float64, force bool) float64 {
 	s.mu.RLock()
 	prices := s.cachedPrices
@@ -377,6 +400,8 @@ func (s *tickerService) price(targetTimestamp float64, force bool) float64 {
 
 	price := float64(0)
 	for _, p := range prices {
+		// cachedPrices timestamps are in milliseconds (e.g. 1711843200000);
+		// targetTimestamp is Unix seconds, so multiply by 1_000 to match.
 		if p[priceTimestamp] > math.Trunc(targetTimestamp)*1_000 {
 			return price
 		}

--- a/api/v1/service/coingecko/ticker_singleflight_test.go
+++ b/api/v1/service/coingecko/ticker_singleflight_test.go
@@ -25,7 +25,7 @@ func TestSingleflightDeduplicatesCoinGeckoRequests(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/"}
+	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/", apiKey: "test-key"}
 
 	const concurrency = 20
 	var wg sync.WaitGroup
@@ -44,9 +44,9 @@ func TestSingleflightDeduplicatesCoinGeckoRequests(t *testing.T) {
 	assert.Equal(t, 2.0, s.price(3_000_000, true), "prices should be cached after fetch")
 }
 
-// TestSingleflightSecondBatchFetchesAgain verifies that after the in-flight
-// call completes, a subsequent call (new batch) does issue a new HTTP request.
-func TestSingleflightSecondBatchFetchesAgain(t *testing.T) {
+// TestSingleflightSecondBatchHitsTTL verifies that a subsequent sequential call
+// within the TTL window does NOT issue a new HTTP request (cache is still valid).
+func TestSingleflightSecondBatchHitsTTL(t *testing.T) {
 	var callCount atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,19 +56,19 @@ func TestSingleflightSecondBatchFetchesAgain(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/"}
+	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/", apiKey: "test-key"}
 
-	// first call
+	// first call — populates cache and sets cacheExpiry
 	_, err, _ := s.sfGroup.Do(priceTokenId, func() (any, error) {
 		return nil, s.cachePriceInUsd(priceTokenId)
 	})
 	assert.NoError(t, err)
 
-	// second call — previous Do has already finished, so a new request goes out
+	// second call within TTL — should be a cache hit, no new HTTP request
 	_, err, _ = s.sfGroup.Do(priceTokenId, func() (any, error) {
 		return nil, s.cachePriceInUsd(priceTokenId)
 	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, int32(2), callCount.Load(), "each independent call should fetch once")
+	assert.Equal(t, int32(1), callCount.Load(), "second call within TTL should not re-fetch")
 }

--- a/api/v1/service/coingecko/ticker_test.go
+++ b/api/v1/service/coingecko/ticker_test.go
@@ -1,9 +1,16 @@
 package coingecko
 
 import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -91,4 +98,103 @@ func TestQueryInactivePools_NoFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, tickers)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestCachePriceInUsdRefetchesAfterTTL verifies that a call after TTL expiry
+// does issue a new HTTP request.
+func TestCachePriceInUsdRefetchesAfterTTL(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"prices":[[1000000,1.0],[2000000,2.0]]}`)
+	}))
+	defer srv.Close()
+
+	s := &tickerService{httpClient: srv.Client(), endpoint: srv.URL + "/", apiKey: "test-key"}
+
+	// first call
+	assert.NoError(t, s.cachePriceInUsd(priceTokenId))
+	assert.Equal(t, int32(1), callCount.Load())
+
+	// simulate TTL expiry
+	s.mu.Lock()
+	s.cacheExpiry = time.Now().Add(-time.Second)
+	s.mu.Unlock()
+
+	// second call after TTL — should re-fetch
+	assert.NoError(t, s.cachePriceInUsd(priceTokenId))
+	assert.Equal(t, int32(2), callCount.Load(), "call after TTL expiry should re-fetch")
+}
+
+// TestNoApiKeyReturnsOnePrice verifies that without an API key no HTTP request
+// is made and price() returns 1.0.
+func TestNoApiKeyReturnsOnePrice(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		fmt.Fprintln(w, `{"prices":[[1000000,2.5]]}`)
+	}))
+	defer srv.Close()
+
+	s := NewTickerService("", nil, "").(*tickerService)
+	s.httpClient = srv.Client()
+	s.endpoint = srv.URL + "/"
+
+	assert.NoError(t, s.cachePriceInUsd(priceTokenId))
+	assert.Equal(t, int32(0), callCount.Load(), "no HTTP request should be made without an API key")
+	assert.Equal(t, 1.0, s.price(3_000_000, true), "price should be 1.0 when no API key is set")
+	assert.Equal(t, 1.0, s.price(3_000_000, false), "price(ts, false) should return 1.0 — trigger block must be skipped")
+}
+
+// TestPrice covers all branches of the price() method.
+// cachedPrices entries are [timestamp_ms, price_usd]; targetTimestamp is
+// converted to ms via math.Trunc(ts)*1_000 before comparison.
+func TestPrice(t *testing.T) {
+	entries := [][priceInfoLength]float64{
+		{1_000_000, 1.0},
+		{2_000_000, 2.0},
+		{3_000_000, 3.0},
+	}
+
+	tests := []struct {
+		name  string
+		cache [][priceInfoLength]float64
+		ts    float64
+		force bool
+		want  float64
+	}{
+		// empty cache
+		{"empty_force", nil, 1_000, true, 0},
+		{"empty_no_force", nil, 1_000, false, 0},
+		// ts before first entry (loop exits immediately, price still 0)
+		{"before_first_force", entries, 0, true, 0},
+		{"before_first_no_force", entries, 0, false, 0},
+		// ts exactly at first entry boundary (equal is not >, entry is consumed)
+		{"at_first_force", entries, 1_000, true, 1.0},
+		{"at_first_no_force", entries, 1_000, false, 1.0},
+		// ts between first and second entry
+		{"between_1_2_force", entries, 1_500, true, 1.0},
+		{"between_1_2_no_force", entries, 1_500, false, 1.0},
+		// ts at last entry (loop exhausts)
+		{"at_last_force", entries, 3_000, true, 3.0},
+		{"at_last_no_force", entries, 3_000, false, 0},
+		// ts beyond all entries (loop exhausts)
+		{"after_last_force", entries, 4_000, true, 3.0},
+		{"after_last_no_force", entries, 4_000, false, 0},
+		// fractional ts — math.Trunc strips the decimal
+		{"fractional_ts", entries, 1_999.9, false, 1.0},
+		// no-key sentinel: {0,1.0},{MaxFloat64,1.0} must return 1.0 without force
+		{"sentinel_no_force", [][priceInfoLength]float64{{0, 1.0}, {math.MaxFloat64, 1.0}}, 3_000_000, false, 1.0},
+		{"sentinel_force", [][priceInfoLength]float64{{0, 1.0}, {math.MaxFloat64, 1.0}}, 3_000_000, true, 1.0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &tickerService{cachedPrices: tc.cache}
+			assert.Equal(t, tc.want, s.price(tc.ts, tc.force))
+		})
+	}
 }

--- a/configs/api_config.go
+++ b/configs/api_config.go
@@ -42,6 +42,7 @@ func apiServerConfig(v *viper.Viper) ApiServerConfig {
 		Mode:               v.GetString("mode"),
 		ChainId:            v.GetString("chain_id"),
 		CorsAllowedOrigins: v.GetStringSlice("cors_allowed_origins"),
+		CoinGeckoApiKey:    v.GetString("coingecko_api_key"),
 	}
 }
 
@@ -57,6 +58,7 @@ func apiServerConfigFromEnv(v *viper.Viper, prefix string) ApiServerConfig {
 		Mode:               v.GetString(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "mode"))),
 		ChainId:            v.GetString(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "chain_id"))),
 		CorsAllowedOrigins: splitAndTrim(v.GetString(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "cors_allowed_origins")))),
+		CoinGeckoApiKey:    v.GetString(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "coingecko_api_key"))),
 	}
 }
 
@@ -75,6 +77,7 @@ type ApiServerConfig struct {
 	Mode               string
 	ChainId            string
 	CorsAllowedOrigins []string
+	CoinGeckoApiKey    string
 }
 
 func (lhs *ApiServerConfig) Override(rhs ApiServerConfig) {
@@ -98,6 +101,9 @@ func (lhs *ApiServerConfig) Override(rhs ApiServerConfig) {
 	}
 	if len(rhs.CorsAllowedOrigins) > 0 {
 		lhs.CorsAllowedOrigins = rhs.CorsAllowedOrigins
+	}
+	if rhs.CoinGeckoApiKey != "" {
+		lhs.CoinGeckoApiKey = rhs.CoinGeckoApiKey
 	}
 }
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CoinGecko ticker service fetches the `axlUSDC/USD `price from the CoinGecko API to calculate USD liquidity values. Previously, no API key was passed to CoinGecko, meaning requests hit the unauthenticated free tier with stricter rate limits. This change wires a configurable API key through the entire stack.

When no API key is configured, the service now short-circuits all CoinGecko HTTP calls and returns a fixed price of 1.0, avoiding unnecessary outbound requests in environments where the key is intentionally omitted.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added `CoinGeckoApiKey` field to `ApiServerConfig`
- `NewTickerService` now accepts an `apiKey string` parameter; when empty, the price cache is pre-seeded with a sentinel `{0, 1.0} / {MaxFloat64, 1.0}` and expiry set to year `9999`, permanently bypassing CoinGecko HTTP calls
- `cachePriceInUsd` sets the `x-cg-demo-api-key` request header and respects a 24-hour TTL cache with RWMutex-guarded expiry
- Added unit tests: no-key sentinel, TTL expiry refetch, `price()` branch coverage, singleflight TTL hit

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?