### PR TITLE
fix: missing error check

### DIFF
--- a/indexer/repo/node.repo.go
+++ b/indexer/repo/node.repo.go
@@ -2,11 +2,12 @@ package repo
 
 import (
 	"context"
+	"time"
+
 	"github.com/dezswap/dezswap-api/indexer"
 	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/dezswap/dezswap-api/pkg/dezswap"
 	"github.com/pkg/errors"
-	"time"
 )
 
 const queryTimeout = 5 * time.Second
@@ -120,11 +121,14 @@ func (r *nodeRepoImpl) cw20FromNode(addr string) (*indexer.Token, error) {
 	}
 
 	token, err := r.resToToken(addr, r.chainId, res)
-	token.Address = addr
-	token.ChainId = r.chainId
 	if err != nil {
 		return nil, errors.Wrap(err, "nodeRepoImpl.cw20FromNode")
 	}
+	if token == nil {
+		return nil, errors.New("token is nil")
+	}
+	token.Address = addr
+	token.ChainId = r.chainId
 	return token, nil
 }
 

--- a/indexer/repo/node.repo_test.go
+++ b/indexer/repo/node.repo_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	ibc_types "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	"github.com/dezswap/dezswap-api/indexer"
 	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/dezswap/dezswap-api/pkg/dezswap"
@@ -17,6 +18,28 @@ import (
 
 	xpla_mock "github.com/dezswap/dezswap-api/pkg/xpla/mock"
 )
+
+type nodeMapperMock struct {
+	mock.Mock
+}
+
+func (m *nodeMapperMock) resToToken(addr, chainId string, data []byte) (*indexer.Token, error) {
+	args := m.Called(addr, chainId, data)
+	token, _ := args.Get(0).(*indexer.Token)
+	return token, args.Error(1)
+}
+
+func (m *nodeMapperMock) resToPoolInfo(addr, chainId string, height uint64, data []byte) (*indexer.PoolInfo, error) {
+	args := m.Called(addr, chainId, height, data)
+	poolInfo, _ := args.Get(0).(*indexer.PoolInfo)
+	return poolInfo, args.Error(1)
+}
+
+func (m *nodeMapperMock) denomTraceToToken(addr, chainId string, trace *ibc_types.Denom) (*indexer.Token, error) {
+	args := m.Called(addr, chainId, trace)
+	token, _ := args.Get(0).(*indexer.Token)
+	return token, args.Error(1)
+}
 
 type nodeRepoSuite struct {
 	suite.Suite
@@ -123,6 +146,42 @@ func (s *nodeRepoSuite) Test_TokenFromNode() {
 		} else {
 			assert.Equal(s.T(), tc.expected, *actual)
 		}
+	}
+}
+
+func (s *nodeRepoSuite) Test_cw20FromNode() {
+	const addr = "xpla1abc"
+	dummyRes := []byte(`{}`)
+
+	tcs := []struct {
+		name      string
+		mapperErr error
+		expectErr string
+	}{
+		{
+			name:      "resToToken returns error",
+			mapperErr: errors.New("parse error"),
+			expectErr: "parse error",
+		},
+		{
+			name:      "resToToken returns nil token",
+			mapperErr: nil,
+			expectErr: "token is nil",
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(tc.name, func() {
+			mapperMock := &nodeMapperMock{}
+			r := nodeRepoImpl{s.ethClient, s.client, mapperMock, s.networkMetadata, s.chainId}
+
+			s.client.(*xpla_mock.GrpcClientMock).On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return(dummyRes, nil).Once()
+			mapperMock.On("resToToken", addr, s.chainId, dummyRes).Return((*indexer.Token)(nil), tc.mapperErr).Once()
+
+			_, err := r.cw20FromNode(addr)
+			s.Require().Error(err)
+			s.True(strings.Contains(err.Error(), tc.expectErr))
+		})
 	}
 }
 

--- a/indexer/repo/node.repo_test.go
+++ b/indexer/repo/node.repo_test.go
@@ -168,6 +168,11 @@ func (s *nodeRepoSuite) Test_cw20FromNode() {
 			mapperErr: nil,
 			expectErr: "token is nil",
 		},
+		{
+			name:      "successful token resolution",
+			mapperErr: nil,
+			expectErr: "",
+		},
 	}
 
 	for _, tc := range tcs {
@@ -176,11 +181,24 @@ func (s *nodeRepoSuite) Test_cw20FromNode() {
 			r := nodeRepoImpl{s.ethClient, s.client, mapperMock, s.networkMetadata, s.chainId}
 
 			s.client.(*xpla_mock.GrpcClientMock).On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return(dummyRes, nil).Once()
-			mapperMock.On("resToToken", addr, s.chainId, dummyRes).Return((*indexer.Token)(nil), tc.mapperErr).Once()
+			
+			var mockToken *indexer.Token
+			if tc.expectErr == "" {
+				mockToken = &indexer.Token{Symbol: "TEST", Name: "Test Token", Decimals: 6}
+			}
+			mapperMock.On("resToToken", addr, s.chainId, dummyRes).Return(mockToken, tc.mapperErr).Once()
 
-			_, err := r.cw20FromNode(addr)
-			s.Require().Error(err)
-			s.True(strings.Contains(err.Error(), tc.expectErr))
+			token, err := r.cw20FromNode(addr)
+			if tc.expectErr != "" {
+				s.Require().Error(err)
+				s.True(strings.Contains(err.Error(), tc.expectErr))
+			} else {
+				s.Require().NoError(err)
+				s.Require().NotNil(token)
+				s.Equal(addr, token.Address)
+				s.Equal(s.chainId, token.ChainId)
+				s.Equal("TEST", token.Symbol)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`cw20FromNode` mutated `token.Address` and `token.ChainId` before checking the error returned by `resToToken`. If `resToToken` returned an error, token would be `nil`, causing a `nil` pointer dereference panic instead of a clean error return. There was also no guard against `resToToken` returning `nil, nil`.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Move `token.Address` and `token.ChainId` assignments to after the error and `nil` checks in `cw20FromNode` (`indexer/repo/node.repo.go`)
- Add an explicit `token == nil` guard that returns a "token is nil" error
- Add `Test_cw20FromNode` covering both cases — `resToToken` returning an error and returning a nil token — using a new `nodeMapperMock` that implements the `nodeMapper` interface

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for CW20 token resolution with proper validation before processing token data.

* **Tests**
  * Added test coverage for token resolution failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/dezswap-api/pull/108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->