### PR TITLE
ci: add Codecov coverage reporting and move build before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ "*" ]
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,6 +44,9 @@ jobs:
 
     - name: Run Golang linter
       uses: golangci/golangci-lint-action@v8
+    
+    - name: Build all
+      run: make build-all
 
     - name: Setup postgres
       run: cd test_supplements && docker compose up -d
@@ -51,7 +57,10 @@ jobs:
         TEST_CONFIG: ${{ secrets.TEST_CONFIG }}
       run: |
         echo "$TEST_CONFIG" > config.yml
-        make test-race
-
-    - name: Build all
-      run: make build-all
+        go test -race -count=1 -short -coverprofile=coverage.out -covermode=atomic ./...
+    
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 18%
+        threshold: 1%
+    patch:
+      default:
+        target: 30%


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI had no coverage tracking, making it impossible to detect regressions in test coverage over time. The build step also ran after tests, meaning a broken build could go unnoticed until after the test suite completed.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Move `make build-all` to before the test step so a broken build fails fast                                                                                                                                                                                    
- Add `codecov/codecov-action@v6` to upload coverage to Codecov after tests
- Add `codecov.yml` with coverage targets: 18% project-wide (1% drop threshold), 30% per-patch

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?