### PR TITLE
perf: enhance dashboard query optimization

### DIFF
--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -32,6 +32,17 @@ var chartCriteriaByDuration = map[Duration]struct {
 
 var _ Dashboard = &dashboard{}
 
+type tokenStat struct {
+	Address          Addr
+	Volume           string
+	VolumeChange     string
+	VolumeWeek       string
+	VolumeWeekChange string
+	Tvl              string
+	TvlChange        string
+	Commission       string
+}
+
 func NewDashboardService(chainId string, db *gorm.DB) Dashboard {
 	return &dashboard{chainId, db}
 }
@@ -568,8 +579,11 @@ where t.chain_id = ?
 }
 
 func (d *dashboard) tokenDetails(addr ...Addr) (Tokens, error) {
-	query := `
+	targetCTEs, args := d.tokenDetailsTargetCTEs(addr...)
+
+	query := fmt.Sprintf(`
 WITH
+%s,
 recent_48h AS (
     SELECT
         ps.pair_id,
@@ -592,6 +606,8 @@ recent_48h AS (
             WHEN ps.timestamp >= extract(epoch from now() - interval '1 day')
             THEN ps.commission1_in_price ELSE 0 END) AS com1_24h
     FROM pair_stats_recent ps
+    JOIN target_pairs p ON p.id = ps.pair_id
+    WHERE ps.chain_id = ?
     GROUP BY ps.pair_id
 ),
 recent_14d AS (
@@ -612,7 +628,9 @@ recent_14d AS (
              AND ps.timestamp >= extract(epoch from now() - interval '14 day')
             THEN ps.volume1_in_price ELSE 0 END) AS vol1_prev
     FROM pair_stats_30m ps
-    WHERE ps.timestamp >= extract(epoch from now() - interval '14 day')
+    JOIN target_pairs p ON p.id = ps.pair_id
+    WHERE ps.chain_id = ?
+      AND ps.timestamp >= extract(epoch from now() - interval '14 day')
     GROUP BY ps.pair_id
 ),
 latest_pair_tvl AS (
@@ -621,6 +639,8 @@ latest_pair_tvl AS (
         ps.liquidity0_in_price,
         ps.liquidity1_in_price
     FROM pair_stats_30m ps
+    JOIN target_pairs p ON p.id = ps.pair_id
+    WHERE ps.chain_id = ?
     ORDER BY ps.pair_id, ps.timestamp DESC
 ),
 pair_tvl_24h_before AS (
@@ -629,7 +649,9 @@ pair_tvl_24h_before AS (
         ps.liquidity0_in_price,
         ps.liquidity1_in_price
     FROM pair_stats_30m ps
-    WHERE ps.timestamp < extract(epoch from now() - interval '1 day')
+    JOIN target_pairs p ON p.id = ps.pair_id
+    WHERE ps.chain_id = ?
+      AND ps.timestamp < extract(epoch from now() - interval '1 day')
     ORDER BY ps.pair_id, ps.timestamp DESC
 )
 SELECT
@@ -651,40 +673,58 @@ FROM (
         COALESCE(SUM(CASE WHEN p.asset0 = t.address THEN r.com0_24h ELSE r.com1_24h END), 0) AS commission,
         COALESCE(SUM(CASE WHEN p.asset0 = t.address THEN l.liquidity0_in_price ELSE l.liquidity1_in_price END), 0) AS tvl,
         COALESCE(SUM(CASE WHEN p.asset0 = t.address THEN lb.liquidity0_in_price ELSE lb.liquidity1_in_price END), 0) AS tvl_24h_before
-    FROM tokens t
-		LEFT JOIN pair p
-			ON p.chain_id = t.chain_id
-		AND (p.asset0 = t.address OR p.asset1 = t.address)
+    FROM target_tokens t
+		LEFT JOIN target_pairs p ON p.asset0 = t.address OR p.asset1 = t.address
 		LEFT JOIN recent_48h r ON r.pair_id = p.id
 		LEFT JOIN recent_14d r14 ON r14.pair_id = p.id
 		LEFT JOIN latest_pair_tvl l ON l.pair_id = p.id
 		LEFT JOIN pair_tvl_24h_before lb ON lb.pair_id = p.id
-    WHERE t.chain_id = ?
-`
-	type tokenStat struct {
-		Address          Addr
-		Volume           string
-		VolumeChange     string
-		VolumeWeek       string
-		VolumeWeekChange string
-		Tvl              string
-		TvlChange        string
-		Commission       string
-	}
-	var stats []tokenStat
-	var tx *gorm.DB
-	if len(addr) > 0 {
-		query += ` AND t.address = ?  GROUP BY t.address) t`
-		tx = d.Raw(query, d.chainId, addr)
-	} else {
-		query += ` GROUP BY t.address) t`
-		tx = d.Raw(query, d.chainId)
-	}
+    GROUP BY t.address
+) t
+`, targetCTEs)
 
-	if err := tx.Find(&stats).Error; err != nil {
+	args = append(args, d.chainId, d.chainId, d.chainId, d.chainId)
+	var stats []tokenStat
+	if err := d.Raw(query, args...).Find(&stats).Error; err != nil {
 		return nil, err
 	}
 
+	return tokenStatsToTokens(stats), nil
+}
+
+// tokenDetailsTargetCTEs scopes all tokens when addr is empty, or one token and its pairs otherwise.
+func (d *dashboard) tokenDetailsTargetCTEs(addr ...Addr) (string, []any) {
+	if len(addr) == 0 {
+		return `
+target_tokens AS (
+    SELECT address
+    FROM tokens
+    WHERE chain_id = ?
+),
+target_pairs AS (
+    SELECT id, asset0, asset1
+    FROM pair
+    WHERE chain_id = ?
+)`, []any{d.chainId, d.chainId}
+	}
+
+	return `
+target_tokens AS (
+    SELECT address
+    FROM tokens
+    WHERE chain_id = ?
+      AND address = ?
+),
+target_pairs AS (
+    SELECT id, asset0, asset1
+    FROM pair
+    WHERE chain_id = ?
+      AND (asset0 = ? OR asset1 = ?)
+)`, []any{d.chainId, addr[0], d.chainId, addr[0], addr[0]}
+}
+
+// tokenStatsToTokens maps raw token aggregate rows to the public token DTOs.
+func tokenStatsToTokens(stats []tokenStat) Tokens {
 	tokens := make(Tokens, len(stats))
 	for i, s := range stats {
 		tokens[i] = Token{
@@ -699,7 +739,7 @@ FROM (
 		}
 	}
 
-	return tokens, nil
+	return tokens
 }
 
 func (d *dashboard) Token(addr Addr) (Token, error) {

--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -211,7 +211,7 @@ func (d *dashboard) Pools(tokens ...Addr) (Pools, error) {
 			WHERE
 				chain_id = '%s'
 			AND
-				TO_TIMESTAMP(timestamp) <= '%s'
+				timestamp <= extract(epoch from '%s'::timestamptz)
 			ORDER BY pair_id, timestamp DESC`,
 			d.chainId, at.UTC().Format(time.DateTime),
 		)
@@ -226,9 +226,9 @@ func (d *dashboard) Pools(tokens ...Addr) (Pools, error) {
 		WHERE
 			ps.chain_id = '%s'
 		AND
-			'%s' < TO_TIMESTAMP(ps."timestamp")
+			ps."timestamp" > extract(epoch from '%s'::timestamptz)
 		AND
-			TO_TIMESTAMP(ps."timestamp") <= '%s'
+			ps."timestamp" <= extract(epoch from '%s'::timestamptz)
 		GROUP BY
 			ps.pair_id
 		ORDER BY ps.pair_id ASC
@@ -318,7 +318,7 @@ func (d *dashboard) Recent() (Recent, error) {
 				WHERE
 					chain_id = '%s'
 				AND
-					TO_TIMESTAMP(timestamp) <= '%s'
+					timestamp <= extract(epoch from '%s'::timestamptz)
 				GROUP BY
 					pair_id) AS latests ON ps.pair_id = latests.pair_id
 			AND ps.timestamp = latests.timestamp`, d.chainId, at.UTC().Format(time.DateTime),
@@ -333,9 +333,9 @@ func (d *dashboard) Recent() (Recent, error) {
 		WHERE
 			chain_id = '%s'
 		AND
-			'%s' < TO_TIMESTAMP("timestamp")
+			"timestamp" > extract(epoch from '%s'::timestamptz)
 		AND
-			TO_TIMESTAMP("timestamp") <= '%s'
+			"timestamp" <= extract(epoch from '%s'::timestamptz)
 		`, d.chainId, from.UTC().Format(time.DateTime), to.UTC().Format(time.DateTime))
 	}
 
@@ -392,7 +392,7 @@ func (d *dashboard) RecentOf(pairContractAddr Addr) (Recent, error) {
 					ps0.chain_id = '%s'
 				AND p.contract = ?
 				AND
-					TO_TIMESTAMP(ps0.timestamp) <= '%s'
+					ps0.timestamp <= extract(epoch from '%s'::timestamptz)
 				GROUP BY
 					ps0.pair_id) AS latests ON ps.pair_id = latests.pair_id
 			AND ps.timestamp = latests.timestamp`, d.chainId, at.UTC().Format(time.DateTime),
@@ -409,9 +409,9 @@ func (d *dashboard) RecentOf(pairContractAddr Addr) (Recent, error) {
 			ps0.chain_id = '%s'
 		AND p.contract = ?
 		AND
-			'%s' < TO_TIMESTAMP(ps0."timestamp")
+			ps0."timestamp" > extract(epoch from '%s'::timestamptz)
 		AND
-			TO_TIMESTAMP(ps0."timestamp") <= '%s'
+			ps0."timestamp" <= extract(epoch from '%s'::timestamptz)
 		`, d.chainId, from.UTC().Format(time.DateTime), to.UTC().Format(time.DateTime))
 	}
 

--- a/api/v1/service/dashboard/dashboard_test.go
+++ b/api/v1/service/dashboard/dashboard_test.go
@@ -191,10 +191,11 @@ INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, ?, 'xerc
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&pairID3))
 
-	generateStats(t, db, time.Now().Truncate(time.Hour).Add(-30*time.Minute))
-	generateStats(t, db, time.Now().Truncate(time.Hour).Add(-25*time.Hour))
-	generateStatsForPair(t, db, pairID3, time.Now().Truncate(time.Hour).Add(-30*time.Minute))
-	generateStatsForPair(t, db, pairID3, time.Now().Truncate(time.Hour).Add(-25*time.Hour))
+	base := time.Now().Truncate(time.Hour)
+	generateStats(t, db, base.Add(-30*time.Minute))
+	generateStats(t, db, base.Add(-25*time.Hour))
+	generateStatsForPair(t, db, pairID3, base.Add(-30*time.Minute))
+	generateStatsForPair(t, db, pairID3, base.Add(-25*time.Hour))
 
 	// Read the broad query result as the expected baseline.
 	d := &dashboard{DB: db, chainId: testChainID}

--- a/api/v1/service/dashboard/dashboard_test.go
+++ b/api/v1/service/dashboard/dashboard_test.go
@@ -28,6 +28,7 @@ var (
 	testPairID            string
 	testPairContractAddr1 = "test1abcd"
 	testPairContractAddr2 = "test1efgh"
+	testPairContractAddr3 = "test1ijkl"
 
 	testTokenID1  string
 	testTokenID2  string
@@ -44,6 +45,7 @@ func SetupDB(t *testing.T) *gorm.DB {
 	)
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
+	cleanupDashboardTestData(t, db)
 
 	row := db.Raw(`
 INSERT INTO tokens (chain_id, address, name, symbol, decimals) VALUES (?, ?, 'Abcd', 'ABCD', 18) RETURNING id
@@ -70,7 +72,23 @@ INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, 'axpla',
 	return db
 }
 
+func cleanupDashboardTestData(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	require.NoError(t, db.Exec(`DELETE FROM parsed_tx WHERE chain_id = ?`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM pair_stats_recent WHERE pair_id IN (SELECT id FROM pair WHERE chain_id = ?)`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM pair_stats_30m WHERE pair_id IN (SELECT id FROM pair WHERE chain_id = ?)`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM price WHERE chain_id = ?`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM pair WHERE chain_id = ?`, testChainID).Error)
+	require.NoError(t, db.Exec(`DELETE FROM tokens WHERE chain_id = ?`, testChainID).Error)
+}
+
 func generateStats(t *testing.T, db *gorm.DB, ts time.Time) {
+	t.Helper()
+	generateStatsForPair(t, db, testPairID, ts)
+}
+
+func generateStatsForPair(t *testing.T, db *gorm.DB, pairID string, ts time.Time) {
 	t.Helper()
 
 	diff := time.Since(ts)
@@ -80,7 +98,7 @@ INSERT INTO pair_stats_recent(
 	pair_id, chain_id, volume0_in_price, volume1_in_price, commission0_in_price, commission1_in_price, height, timestamp)
 VALUES(
 	?, ?, 123.45, 678.90, 12.34, 56.78, 1, ?)
-`, testPairID, testChainID, ts.Unix()).Error)
+`, pairID, testChainID, ts.Unix()).Error)
 	}
 
 	require.NoError(t, db.Exec(`
@@ -109,7 +127,7 @@ VALUES(
 	    ?, ?
 	)
 	`, ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(),
-		testPairID, testChainID,
+		pairID, testChainID,
 		ts.Unix(),
 		ts.Unix(), ts.Unix()).Error)
 }
@@ -140,13 +158,67 @@ VALUES(?, ?, EXTRACT(EPOCH FROM NOW() - INTERVAL '1 day'), 'dummy_hash', 'dummy_
 func CleanupDB(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
-	require.NoError(t, db.Exec(`DELETE FROM parsed_tx WHERE chain_id = ?`, testChainID).Error)
-	require.NoError(t, db.Exec(`DELETE FROM pair_stats_30m WHERE pair_id IN (SELECT id FROM pair WHERE chain_id = ?)`, testChainID).Error)
-	require.NoError(t, db.Exec(`DELETE FROM pair WHERE chain_id = ?`, testChainID).Error)
-	require.NoError(t, db.Exec(`DELETE FROM tokens WHERE chain_id = ?`, testChainID).Error)
+	cleanupDashboardTestData(t, db)
 
 	if sqlDB, err := db.DB(); err == nil {
 		_ = sqlDB.Close()
+	}
+}
+
+func TestTokenDetailsOf_MatchesFilteredTokenDetails(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	// Add tokens that cover shared pairs and a token with no pair stats.
+	var extraTokenID string
+	row := db.Raw(`
+INSERT INTO tokens (chain_id, address, name, symbol, decimals) VALUES (?, 'xerc20:EFGH', 'Efgh', 'EFGH', 18) RETURNING id
+`, testChainID).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&extraTokenID))
+
+	row = db.Raw(`
+INSERT INTO tokens (chain_id, address, name, symbol, decimals) VALUES (?, 'xerc20:NONE', 'None', 'NONE', 18) RETURNING id
+`, testChainID).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(new(string)))
+
+	// Add a second active pair so one token aggregates across multiple pairs.
+	var pairID3 string
+	row = db.Raw(`
+INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, ?, 'xerc20:EFGH', 'xpla1lp3') RETURNING id
+`, testChainID, testPairContractAddr3, testTokenAddr).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&pairID3))
+
+	generateStats(t, db, time.Now().Truncate(time.Hour).Add(-30*time.Minute))
+	generateStats(t, db, time.Now().Truncate(time.Hour).Add(-25*time.Hour))
+	generateStatsForPair(t, db, pairID3, time.Now().Truncate(time.Hour).Add(-30*time.Minute))
+	generateStatsForPair(t, db, pairID3, time.Now().Truncate(time.Hour).Add(-25*time.Hour))
+
+	// Read the broad query result as the expected baseline.
+	d := &dashboard{DB: db, chainId: testChainID}
+
+	allTokens, err := d.tokenDetails()
+	require.NoError(t, err)
+	require.Len(t, allTokens, 4)
+
+	expectedByAddr := make(map[Addr]Token, len(allTokens))
+	for _, token := range allTokens {
+		expectedByAddr[token.Addr] = token
+	}
+	require.Contains(t, expectedByAddr, Addr(testTokenAddr))
+	require.Contains(t, expectedByAddr, Addr("axpla"))
+	require.Contains(t, expectedByAddr, Addr("xerc20:EFGH"))
+	require.Contains(t, expectedByAddr, Addr("xerc20:NONE"))
+	require.NotZero(t, extraTokenID)
+
+	// Compare every token's scoped query result with its broad query row.
+	for addr, expected := range expectedByAddr {
+		tokenDetails, err := d.tokenDetails(addr)
+		require.NoError(t, err)
+		require.Len(t, tokenDetails, 1)
+		assert.Equal(t, expected, tokenDetails[0])
 	}
 }
 

--- a/test_supplements/init.sql
+++ b/test_supplements/init.sql
@@ -16,8 +16,8 @@ CREATE UNIQUE INDEX pair_chain_id_lp_key ON pair (chain_id, lp);
 
 CREATE TABLE tokens (
     id         BIGSERIAL                    PRIMARY KEY,
-    created_at TIMESTAMP WITH TIME ZONE,
-    updated_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     deleted_at TIMESTAMP WITH TIME ZONE,
     chain_id   TEXT                         NOT NULL,
     address    TEXT                         NOT NULL,


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some dashboard statistics queries applied `TO_TIMESTAMP(...)` to the `timestamp` column in range filters, and token detail queries aggregated across a broad token/pair/stat scope before applying the target token filter.

This could limit effective index usage for timestamp range conditions and cause unnecessary pair/stat scans, especially for single-token detail requests.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Changed `pair_stats_*` timestamp range filters from `TO_TIMESTAMP(timestamp)` comparisons to direct epoch timestamp comparisons.
- This avoids applying functions to the timestamp column and allows range filters to execute more efficiently.
- Added `target_tokens` and `target_pairs` CTEs to the token detail query.
  - Full token detail queries still operate at the chain scope.
  - Single-token detail queries now narrow the working set to the requested token and its related pairs before aggregating stats.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard timestamp comparisons for accurate data filtering across pools and recent transaction queries.
  * Enhanced token details aggregation logic for precise filtering and grouping.
  * Fixed database timestamp column initialization to ensure proper default values.

* **Tests**
  * Expanded test coverage for multi-pair scenarios and token-scoped query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->