### PR TITLE
fix: AMM metrics calculation

### DIFF
--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -16,6 +16,9 @@ type dashboard struct {
 	*gorm.DB
 }
 
+// Annualizes 7-day fee yield into APR.
+const weekAprMultiplier = dezswap.SWAP_FEE * 365 / 7
+
 var chartCriteriaByDuration = map[Duration]struct {
 	Ago     string
 	TruncBy string
@@ -124,7 +127,7 @@ func (d *dashboard) Aprs(duration Duration) (Aprs, error) {
 	JOIN tvl AS t ON ds.timestamp = t.timestamp
 	JOIN volume7d AS v ON ds.timestamp = v.timestamp
 	ORDER BY ds.timestamp;
-	`, dateSeries, lastQuery, joinClause, dezswap.SWAP_FEE)
+	`, dateSeries, lastQuery, joinClause, weekAprMultiplier)
 
 	aprs := Aprs{}
 	if err := d.DB.Raw(query, d.chainId, d.chainId).Scan(&aprs).Error; err != nil {
@@ -201,7 +204,7 @@ func (d *dashboard) AprsOf(pool Addr, duration Duration) ([]Apr, error) {
 	JOIN tvl AS t ON ds.timestamp = t.timestamp
 	JOIN volume7d AS v ON ds.timestamp = v.timestamp
 	ORDER BY ds.timestamp;
-	`, dateSeries, d.chainId, d.chainId, d.chainId, dezswap.SWAP_FEE)
+	`, dateSeries, d.chainId, d.chainId, d.chainId, weekAprMultiplier)
 
 	aprs := Aprs{}
 	if err := d.DB.Raw(query, pool, pool).Scan(&aprs).Error; err != nil {
@@ -272,7 +275,7 @@ func (d *dashboard) Pools(tokens ...Addr) (Pools, error) {
 		WHERE
 			p.chain_id = '%s'
 		`,
-		tvl(current), volume(dayAgo, current), volume(sevenDaysAgo, current), dezswap.SWAP_FEE, dezswap.SWAP_FEE, d.chainId,
+		tvl(current), volume(dayAgo, current), volume(sevenDaysAgo, current), dezswap.SWAP_FEE, weekAprMultiplier, d.chainId,
 	)
 
 	orderBy := `ORDER BY p.contract`
@@ -364,16 +367,16 @@ func (d *dashboard) Recent() (Recent, error) {
 			prev_volume7d as (%s)
 		SELECT
 			tvl.tvl AS tvl,
-			CAST((tvl.tvl / prev_tvl.tvl - 1) AS float4) AS tvl_change_rate,
+			COALESCE((tvl.tvl / NULLIF(prev_tvl.tvl, 0) - 1)::float4, 0) AS tvl_change_rate,
 			volume.volume AS volume,
-			CAST((volume.volume / prev_volume.volume - 1) AS float4) AS volume_change_rate,
+			COALESCE((volume.volume / NULLIF(prev_volume.volume, 0) - 1)::float4, 0) AS volume_change_rate,
 			volume.volume * %f as fee,
-			CAST((volume.volume / prev_volume.volume - 1) AS float4) AS fee_change_rate,
-			volume7d.volume / tvl.tvl * %f as apr,
-			(volume7d.volume / tvl.tvl) / (prev_volume7d.volume / prev_tvl.tvl) - 1 AS apr_change_rate
+			COALESCE((volume.volume / NULLIF(prev_volume.volume, 0) - 1)::float4, 0) AS fee_change_rate,
+			COALESCE(volume7d.volume / NULLIF(tvl.tvl, 0), 0) * %f as apr,
+			COALESCE((volume7d.volume / NULLIF(tvl.tvl, 0)) / NULLIF(prev_volume7d.volume / NULLIF(prev_tvl.tvl, 0), 0) - 1, 0) AS apr_change_rate
 		FROM
 			tvl, prev_tvl, volume, prev_volume, volume7d, prev_volume7d;
-	`, tvl(current), tvl(dayAgo), volume(dayAgo, current), volume(twoDaysAgo, dayAgo), volume(sevenDaysAgo, current), volume(eightDaysAgo, dayAgo), dezswap.SWAP_FEE, dezswap.SWAP_FEE)
+	`, tvl(current), tvl(dayAgo), volume(dayAgo, current), volume(twoDaysAgo, dayAgo), volume(sevenDaysAgo, current), volume(eightDaysAgo, dayAgo), dezswap.SWAP_FEE, weekAprMultiplier)
 	recent := Recent{}
 	if err := d.DB.Raw(query).Scan(&recent).Error; err != nil {
 		return recent, errors.Wrap(err, "dashboard.Recent")
@@ -450,7 +453,7 @@ func (d *dashboard) RecentOf(pairContractAddr Addr) (Recent, error) {
 			COALESCE((volume7d.volume / NULLIF(tvl.tvl, 0)) / NULLIF(prev_volume7d.volume / NULLIF(prev_tvl.tvl, 0), 0) - 1, 0) AS apr_change_rate
 		FROM
 			tvl, prev_tvl, volume, prev_volume, volume7d, prev_volume7d
-	`, tvl(current), tvl(dayAgo), volume(dayAgo, current), volume(twoDaysAgo, dayAgo), volume(sevenDaysAgo, current), volume(eightDaysAgo, dayAgo), d.chainId, dezswap.SWAP_FEE, dezswap.SWAP_FEE)
+	`, tvl(current), tvl(dayAgo), volume(dayAgo, current), volume(twoDaysAgo, dayAgo), volume(sevenDaysAgo, current), volume(eightDaysAgo, dayAgo), d.chainId, dezswap.SWAP_FEE, weekAprMultiplier)
 	recent := Recent{}
 	if err := d.DB.Raw(query, pairContractAddr, pairContractAddr, pairContractAddr, pairContractAddr, pairContractAddr, pairContractAddr, pairContractAddr).Scan(&recent).Error; err != nil {
 		return recent, errors.Wrap(err, "dashboard.RecentOf")

--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -853,12 +853,13 @@ from (
                      date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '6 days' -- last day of the 2nd week
                  else
                      date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '13 days' -- next week's last day of the 1st week
-                 end as eow2, * from pair_stats_30m) ps
+                 end as eow2, *
+          from pair_stats_30m
+          where chain_id = ?
+            and timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')) ps
     join pair p on p.id = ps.pair_id
     join tokens t on p.chain_id = t.chain_id and (p.asset0 = t.address or p.asset1 = t.address)
-    where ps.chain_id = ?
-      and t.address = ?
-      and ps.timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')
+    where t.address = ?
     group by eow2, p.asset0, t.address
 ) t
 group by eow2
@@ -921,12 +922,12 @@ from (select distinct pair_id, eow,
            end as tvl
     from (select date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '6 days' as eow, -- last day of week
                  *
-          from pair_stats_30m) ps
+          from pair_stats_30m
+          where chain_id = ?
+            and timestamp >= extract(epoch from date_trunc('day', now()) - interval '3 month')) ps
     join pair p on p.id = ps.pair_id
     join tokens t on p.chain_id = t.chain_id and (p.asset0 = t.address or p.asset1 = t.address)
-    where ps.chain_id = ?
-      and t.address = ?
-      and ps.timestamp >= extract(epoch from date_trunc('day', now()) - interval '3 month')) t
+    where t.address = ?) t
 group by eow
 order by eow
 `
@@ -946,12 +947,12 @@ from (select distinct on (pair_id, eow2)
                      date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '13 days' -- next week's last day of the 1st week
                  end as eow2,
                  *
-          from pair_stats_30m) ps
+          from pair_stats_30m
+          where chain_id = ?
+            and timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')) ps
     join pair p on p.id = ps.pair_id
     join tokens t on p.chain_id = t.chain_id and (p.asset0 = t.address or p.asset1 = t.address)
-    where ps.chain_id = ?
-      and t.address = ?
-      and ps.timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')) t
+    where t.address = ?) t
 group by eow2
 order by eow2
 `
@@ -1019,10 +1020,10 @@ from (select p.height, eow2, p.price
                            date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '13 days' -- next week's last day of the 1st week
                        end as eow2,
                        *
-                from parsed_tx) pt on p.chain_id = pt.chain_id and p.tx_id = pt.id
-      where pt.chain_id = ?
-        and (pt.asset0 = ? or pt.asset1 = ?)
-        and pt.timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')) t
+                from parsed_tx
+                where chain_id = ?
+                  and (asset0 = ? or asset1 = ?)
+                  and timestamp >= extract(epoch from date_trunc('day', now()) - interval '1 year')) pt on p.chain_id = pt.chain_id and p.tx_id = pt.id) t
 `
 	}
 
@@ -1191,8 +1192,8 @@ func (d *dashboard) Txs(txType TxType, addr ...Addr) (Txs, error) {
 	).Table("(?) AS pt", subQuery).Joins(`
 		JOIN tokens AS t0 ON pt.asset0 = t0.address AND pt.chain_id = t0.chain_id
 		JOIN tokens AS t1 ON pt.asset1 = t1.address AND pt.chain_id = t1.chain_id
-		LEFT JOIN LATERAL (select price from price p join (SELECT max(tx_id) tx_id FROM price WHERE token_id = t0.id AND tx_id <= pt.id) t on p.tx_id = t.tx_id where p.token_id = t0.id) pr0 ON TRUE
-		LEFT JOIN LATERAL (select price from price p join (SELECT max(tx_id) tx_id FROM price WHERE token_id = t1.id AND tx_id <= pt.id) t on p.tx_id = t.tx_id where p.token_id = t1.id) pr1 ON TRUE
+		LEFT JOIN LATERAL (SELECT price FROM price p WHERE p.token_id = t0.id AND p.tx_id <= pt.id ORDER BY p.tx_id DESC LIMIT 1) pr0 ON TRUE
+		LEFT JOIN LATERAL (SELECT price FROM price p WHERE p.token_id = t1.id AND p.tx_id <= pt.id ORDER BY p.tx_id DESC LIMIT 1) pr1 ON TRUE
 	`,
 	).Order(`pt. "timestamp" DESC`)
 
@@ -1241,8 +1242,8 @@ func (d *dashboard) TxsOfToken(txType TxType, tokenAddrs ...Addr) (Txs, error) {
 	).Table("(?) AS pt", subQuery).Joins(`
 		JOIN tokens AS t0 ON pt.asset0 = t0.address AND pt.chain_id = t0.chain_id
 		JOIN tokens AS t1 ON pt.asset1 = t1.address AND pt.chain_id = t1.chain_id
-		LEFT JOIN LATERAL (select price from price p join (SELECT max(tx_id) tx_id FROM price WHERE token_id = t0.id AND tx_id <= pt.id) t on p.tx_id = t.tx_id where p.token_id = t0.id) pr0 ON TRUE
-		LEFT JOIN LATERAL (select price from price p join (SELECT max(tx_id) tx_id FROM price WHERE token_id = t1.id AND tx_id <= pt.id) t on p.tx_id = t.tx_id where p.token_id = t1.id) pr1 ON TRUE
+		LEFT JOIN LATERAL (SELECT price FROM price p WHERE p.token_id = t0.id AND p.tx_id <= pt.id ORDER BY p.tx_id DESC LIMIT 1) pr0 ON TRUE
+		LEFT JOIN LATERAL (SELECT price FROM price p WHERE p.token_id = t1.id AND p.tx_id <= pt.id ORDER BY p.tx_id DESC LIMIT 1) pr1 ON TRUE
 	`,
 	).Order(`pt. "timestamp" DESC`)
 

--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -110,6 +110,7 @@ func (d *dashboard) Aprs(duration Duration) (Aprs, error) {
 			ds
 		LEFT JOIN pair_stats_30m AS ps ON ps. "timestamp" <= ds.timestamp
 			AND ps. "timestamp" > (ds.timestamp - EXTRACT(EPOCH FROM INTERVAL '7 days'))
+			AND ps.chain_id = ?
 		GROUP BY
 			ds.timestamp
 		ORDER BY
@@ -126,7 +127,7 @@ func (d *dashboard) Aprs(duration Duration) (Aprs, error) {
 	`, dateSeries, lastQuery, joinClause, dezswap.SWAP_FEE)
 
 	aprs := Aprs{}
-	if err := d.DB.Raw(query, d.chainId).Scan(&aprs).Error; err != nil {
+	if err := d.DB.Raw(query, d.chainId, d.chainId).Scan(&aprs).Error; err != nil {
 		return nil, errors.Wrap(err, "dashboard.Aprs")
 	}
 	return aprs, nil
@@ -181,8 +182,12 @@ func (d *dashboard) AprsOf(pool Addr, duration Duration) ([]Apr, error) {
 			ds.timestamp
 		FROM
 			ds
-		LEFT JOIN pair_stats_30m AS ps ON ps. "timestamp" <= ds.timestamp
+		LEFT JOIN pair AS p ON p.chain_id = '%s'
+			AND p.contract = ?
+		LEFT JOIN pair_stats_30m AS ps ON ps.pair_id = p.id
+			AND ps. "timestamp" <= ds.timestamp
 			AND ps. "timestamp" > (ds.timestamp - EXTRACT(EPOCH FROM INTERVAL '7 days'))
+			AND ps.chain_id = '%s'
 		GROUP BY
 			ds.timestamp
 		ORDER BY
@@ -196,10 +201,10 @@ func (d *dashboard) AprsOf(pool Addr, duration Duration) ([]Apr, error) {
 	JOIN tvl AS t ON ds.timestamp = t.timestamp
 	JOIN volume7d AS v ON ds.timestamp = v.timestamp
 	ORDER BY ds.timestamp;
-	`, dateSeries, d.chainId, dezswap.SWAP_FEE)
+	`, dateSeries, d.chainId, d.chainId, d.chainId, dezswap.SWAP_FEE)
 
 	aprs := Aprs{}
-	if err := d.DB.Raw(query, pool).Scan(&aprs).Error; err != nil {
+	if err := d.DB.Raw(query, pool, pool).Scan(&aprs).Error; err != nil {
 		return nil, errors.Wrap(err, "dashboard.AprsOf")
 	}
 	return aprs, nil

--- a/api/v1/service/dashboard/dashboard.go
+++ b/api/v1/service/dashboard/dashboard.go
@@ -881,7 +881,7 @@ from (select distinct pair_id, year_utc, month_utc,
            case when p.asset0 = t.address then
                first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, month_utc order by timestamp desc)
            else
-               first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, month_utc order by timestamp desc)
+               first_value(ps.liquidity1_in_price) over (partition by pair_id, year_utc, month_utc order by timestamp desc)
            end as tvl
     from pair_stats_30m ps
     join pair p on p.id = ps.pair_id
@@ -899,7 +899,7 @@ from (select distinct pair_id, year_utc, month_utc, day_utc,
            case when p.asset0 = t.address then
                first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, month_utc, day_utc order by timestamp desc)
            else
-               first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, month_utc, day_utc order by timestamp desc)
+               first_value(ps.liquidity1_in_price) over (partition by pair_id, year_utc, month_utc, day_utc order by timestamp desc)
            end as tvl
     from pair_stats_30m ps
     join pair p on p.id = ps.pair_id
@@ -917,7 +917,7 @@ from (select distinct pair_id, eow,
            case when p.asset0 = t.address then
                first_value(ps.liquidity0_in_price) over (partition by pair_id, eow order by timestamp desc)
            else
-               first_value(ps.liquidity0_in_price) over (partition by pair_id, eow order by timestamp desc)
+               first_value(ps.liquidity1_in_price) over (partition by pair_id, eow order by timestamp desc)
            end as tvl
     from (select date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '6 days' as eow, -- last day of week
                  *
@@ -938,7 +938,7 @@ from (select distinct on (pair_id, eow2)
            case when p.asset0 = t.address then
                first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, eow2 order by timestamp desc)
            else
-               first_value(ps.liquidity0_in_price) over (partition by pair_id, year_utc, eow2 order by timestamp desc)
+               first_value(ps.liquidity1_in_price) over (partition by pair_id, year_utc, eow2 order by timestamp desc)
            end as tvl
     from (select case when mod(cast(extract(week from to_timestamp(timestamp)) as bigint),2) = 0 then
                      date_trunc('week', to_timestamp(timestamp) at time zone 'UTC') + interval '6 days' -- last day of the 2nd week

--- a/api/v1/service/dashboard/dashboard_test.go
+++ b/api/v1/service/dashboard/dashboard_test.go
@@ -90,6 +90,11 @@ func generateStats(t *testing.T, db *gorm.DB, ts time.Time) {
 
 func generateStatsForPair(t *testing.T, db *gorm.DB, pairID string, ts time.Time) {
 	t.Helper()
+	generateStatsForPairWithValues(t, db, pairID, testChainID, ts, "123.45", "678.90", "1111.11", "2222.22")
+}
+
+func generateStatsForPairWithValues(t *testing.T, db *gorm.DB, pairID string, chainID string, ts time.Time, volume0 string, volume1 string, liquidity0 string, liquidity1 string) {
+	t.Helper()
 
 	diff := time.Since(ts)
 	if diff.Microseconds() > 0 && diff.Microseconds() < (48*time.Hour).Microseconds() {
@@ -97,8 +102,8 @@ func generateStatsForPair(t *testing.T, db *gorm.DB, pairID string, ts time.Time
 INSERT INTO pair_stats_recent(
 	pair_id, chain_id, volume0_in_price, volume1_in_price, commission0_in_price, commission1_in_price, height, timestamp)
 VALUES(
-	?, ?, 123.45, 678.90, 12.34, 56.78, 1, ?)
-`, pairID, testChainID, ts.Unix()).Error)
+	?, ?, ?, ?, 12.34, 56.78, 1, ?)
+`, pairID, chainID, volume0, volume1, ts.Unix()).Error)
 	}
 
 	require.NoError(t, db.Exec(`
@@ -117,9 +122,9 @@ VALUES(
 	VALUES (
 	    ?, ?, ?, ?, ?,
 	    ?, ?,
-	    100, 200, 123.45, 678.90,
+	    100, 200, ?, ?,
 	    1.23,
-	    1000, 2000, 1111.11, 2222.22,
+	    1000, 2000, ?, ?,
 	    10, 20, 12.34, 56.78,
 	    'ibc/ABCD',
 	    5, 2,
@@ -127,7 +132,9 @@ VALUES(
 	    ?, ?
 	)
 	`, ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(),
-		pairID, testChainID,
+		pairID, chainID,
+		volume0, volume1,
+		liquidity0, liquidity1,
 		ts.Unix(),
 		ts.Unix(), ts.Unix()).Error)
 }
@@ -242,6 +249,21 @@ func TestRecentOf_NoDivisionByZero_WithPrevZeros(t *testing.T) {
 	assert.Equal(t, float32(0), recent.AprChangeRate)
 }
 
+func TestRecent_NoDivisionByZero_WithPrevZeros(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+	generateStatsForPairWithValues(t, db, testPairID, testChainID, time.Now().Truncate(time.Hour).Add(-30*time.Minute), "100", "0", "1000", "1000")
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	recent, err := d.Recent()
+	require.NoError(t, err)
+
+	assert.Equal(t, float32(0), recent.VolumeChangeRate)
+	assert.Equal(t, float32(0), recent.FeeChangeRate)
+	assert.Equal(t, float32(0), recent.TvlChangeRate)
+	assert.Equal(t, float32(0), recent.AprChangeRate)
+}
+
 func TestTokens_NoTransaction48h(t *testing.T) {
 	db := SetupDB(t)
 	defer CleanupDB(t, db)
@@ -351,6 +373,72 @@ func TestTestTokenTvls(t *testing.T) {
 		_, err = strconv.ParseInt(chart[0].Timestamp, 10, 64)
 		require.NoError(t, err)
 	})
+
+	t.Run("Asset1 uses asset1 liquidity", func(t *testing.T) {
+		chart, err := d.TokenTvls(addr, Month)
+		require.NoError(t, err)
+		require.NotEmpty(t, chart)
+
+		assert.Equal(t, "2222.22", chart[len(chart)-1].Value)
+	})
+}
+
+func TestAprsOf_UsesOnlyTargetPoolVolume(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	var otherPairID string
+	row := db.Raw(`
+INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, ?, 'axpla', 'xerc20:OTHER', 'xpla1lp3') RETURNING id
+`, testChainID, testPairContractAddr3).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&otherPairID))
+
+	ts := time.Now().Truncate(time.Hour).Add(-30 * time.Minute)
+	generateStatsForPairWithValues(t, db, testPairID, testChainID, ts, "100", "0", "1000", "1000")
+	generateStatsForPairWithValues(t, db, otherPairID, testChainID, ts, "1000000", "0", "1000", "1000")
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	aprs, err := d.AprsOf(Addr(testPairContractAddr2), Month)
+	require.NoError(t, err)
+	require.NotEmpty(t, aprs)
+
+	actual, err := strconv.ParseFloat(aprs[len(aprs)-1].Apr, 64)
+	require.NoError(t, err)
+	expected := 100.0 / 2000.0 * weekAprMultiplier
+	assert.InDelta(t, expected, actual, 0.000001)
+}
+
+func TestAprs_ExcludesOtherChainVolume(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	otherChainID := "otherchain-1"
+	var otherPairID string
+	row := db.Raw(`
+INSERT INTO pair (chain_id, contract, asset0, asset1, lp) VALUES (?, 'otherpair', 'axpla', ?, 'xpla1lp-other') RETURNING id
+`, otherChainID, testTokenAddr).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&otherPairID))
+
+	ts := time.Now().Truncate(time.Hour).Add(-30 * time.Minute)
+	generateStatsForPairWithValues(t, db, testPairID, testChainID, ts, "100", "0", "1000", "1000")
+	generateStatsForPairWithValues(t, db, otherPairID, otherChainID, ts, "1000000", "0", "1000", "1000")
+	defer func() {
+		require.NoError(t, db.Exec(`DELETE FROM pair_stats_recent WHERE pair_id = ?`, otherPairID).Error)
+		require.NoError(t, db.Exec(`DELETE FROM pair_stats_30m WHERE pair_id = ?`, otherPairID).Error)
+		require.NoError(t, db.Exec(`DELETE FROM pair WHERE chain_id = ?`, otherChainID).Error)
+	}()
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	aprs, err := d.Aprs(Month)
+	require.NoError(t, err)
+	require.NotEmpty(t, aprs)
+
+	actual, err := strconv.ParseFloat(aprs[len(aprs)-1].Apr, 64)
+	require.NoError(t, err)
+	expected := 100.0 / 2000.0 * weekAprMultiplier
+	assert.InDelta(t, expected, actual, 0.000001)
 }
 
 func TestPools_NewPairAppearsWithoutStats(t *testing.T) {
@@ -446,6 +534,36 @@ func TestTxs_SwapWithTransfer_TransferHidden(t *testing.T) {
 	assert.Equal(t, hash, txs[0].Hash)
 	assert.Equal(t, "1000", txs[0].Asset0Amount)
 	assert.Equal(t, "2000", txs[0].Asset1Amount)
+}
+
+func TestTxs_UsesLatestPriceAtOrBeforeTx(t *testing.T) {
+	db := SetupDB(t)
+	defer CleanupDB(t, db)
+
+	var txID int64
+	row := db.Raw(`
+INSERT INTO parsed_tx(chain_id, height, timestamp, hash, sender, type, contract, asset0, asset0_amount, asset1, asset1_amount, lp_amount)
+VALUES(?, 1, EXTRACT(EPOCH FROM NOW()), 'priced_hash', 'test_sender', 'swap', ?, 'axpla', 1000000000000000000, ?, 2000000000000000000, 0)
+RETURNING id
+`, testChainID, testPairContractAddr2, testTokenAddr).Row()
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&txID))
+
+	require.NoError(t, db.Exec(`
+INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id, tx_id)
+VALUES(1, ?, ?, 7, ?, 1, ?)
+`, testChainID, testTokenID2, testTokenID1, txID-1).Error)
+	require.NoError(t, db.Exec(`
+INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id, tx_id)
+VALUES(1, ?, ?, 9, ?, 1, ?)
+`, testChainID, testTokenID2, testTokenID1, txID+1).Error)
+
+	d := &dashboard{DB: db, chainId: testChainID}
+	txs, err := d.Txs(TX_TYPE_ALL)
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+
+	assert.Equal(t, "7", txs[0].TotalValue)
 }
 
 // TestTxs_TransferOnly_ExcludedRegardlessOfAssets verifies that transfer-only hashes are excluded

--- a/api/v1/service/stat.go
+++ b/api/v1/service/stat.go
@@ -26,6 +26,12 @@ const (
 	statPeriod1mon = "1mon"
 )
 
+var aprAnnualizationByPeriod = map[string]math.LegacyDec{
+	statPeriod24h:  math.LegacyNewDec(365),
+	statPeriod7d:   math.LegacyNewDec(365).QuoInt64(7),
+	statPeriod1mon: math.LegacyNewDec(12),
+}
+
 type statService struct {
 	chainId string
 	*gorm.DB
@@ -49,7 +55,7 @@ func (s *statService) Get(key string) (*PairStats, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "statService.Get")
 		}
-		pairStats := s.mapToSlice(pairStatMap)
+		pairStats := s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[key])
 
 		return &pairStats, nil
 	case statPeriod7d, statPeriod1mon:
@@ -73,7 +79,7 @@ func (s *statService) Get(key string) (*PairStats, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "statService.Get")
 		}
-		pairStats := s.mapToSlice(pairStatMap)
+		pairStats := s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[key])
 
 		return &pairStats, nil
 	default:
@@ -104,7 +110,7 @@ func (s *statService) GetAll() ([]PairStats, error) {
 	}
 
 	if len(stats30m) == 0 {
-		pairStatsByPeriod[Period24h] = s.mapToSlice(pairStatMap)
+		pairStatsByPeriod[Period24h] = s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod24h])
 		return pairStatsByPeriod, nil
 	}
 
@@ -119,11 +125,11 @@ func (s *statService) GetAll() ([]PairStats, error) {
 
 		for _, stat := range stats30m {
 			if stat.Timestamp < float64(tsBefore24h) && !done24h {
-				pairStatsByPeriod[Period24h] = s.mapToSlice(pairStatMap)
+				pairStatsByPeriod[Period24h] = s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod24h])
 				done24h = true
 			}
 			if stat.Timestamp < float64(tsBefore7d) && !done7d {
-				pairStatsByPeriod[Period7d] = s.mapToSlice(pairStatMap)
+				pairStatsByPeriod[Period7d] = s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod7d])
 				done7d = true
 			}
 
@@ -131,7 +137,7 @@ func (s *statService) GetAll() ([]PairStats, error) {
 				return nil, errors.Wrap(err, "statService.GetAll")
 			}
 		}
-		pairStatsByPeriod[Period1mon] = s.mapToSlice(pairStatMap)
+		pairStatsByPeriod[Period1mon] = s.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod1mon])
 	}
 
 	return pairStatsByPeriod, nil
@@ -233,7 +239,7 @@ func (s *statService) sumPairStat(stat db.PairStat, sumStatMap map[string][count
 	return nil
 }
 
-func (s *statService) mapToSlice(pairStatMap map[string][countOfStatType]math.LegacyDec) PairStats {
+func (s *statService) mapToSlice(pairStatMap map[string][countOfStatType]math.LegacyDec, aprAnnualization math.LegacyDec) PairStats {
 	pairStats := make(PairStats, 0, len(pairStatMap))
 	for k, v := range pairStatMap {
 		pairStats = append(
@@ -242,7 +248,7 @@ func (s *statService) mapToSlice(pairStatMap map[string][countOfStatType]math.Le
 				Address:           k,
 				VolumeInPrice:     v[statVolume].String(),
 				CommissionInPrice: v[statCommission].String(),
-				AprInPrice:        v[statCommission].Quo(v[statLiquidity]).MulInt64(100).String(),
+				AprInPrice:        v[statCommission].Quo(v[statLiquidity]).Mul(aprAnnualization).MulInt64(100).String(),
 			})
 	}
 

--- a/api/v1/service/stat.go
+++ b/api/v1/service/stat.go
@@ -242,13 +242,18 @@ func (s *statService) sumPairStat(stat db.PairStat, sumStatMap map[string][count
 func (s *statService) mapToSlice(pairStatMap map[string][countOfStatType]math.LegacyDec, aprAnnualization math.LegacyDec) PairStats {
 	pairStats := make(PairStats, 0, len(pairStatMap))
 	for k, v := range pairStatMap {
+		aprInPrice := "0"
+		if !v[statLiquidity].IsZero() {
+			aprInPrice = v[statCommission].Quo(v[statLiquidity]).Mul(aprAnnualization).MulInt64(100).String()
+		}
+
 		pairStats = append(
 			pairStats,
 			PairStat{
 				Address:           k,
 				VolumeInPrice:     v[statVolume].String(),
 				CommissionInPrice: v[statCommission].String(),
-				AprInPrice:        v[statCommission].Quo(v[statLiquidity]).Mul(aprAnnualization).MulInt64(100).String(),
+				AprInPrice:        aprInPrice,
 			})
 	}
 

--- a/api/v1/service/stat_test.go
+++ b/api/v1/service/stat_test.go
@@ -86,3 +86,20 @@ func TestStatService_MapToSlice_AnnualizesAprByPeriod(t *testing.T) {
 	require.Len(t, stats1mon, 1)
 	require.Equal(t, "84.000000000000000000", stats1mon[0].AprInPrice)
 }
+
+func TestStatService_MapToSlice_ZeroLiquidity(t *testing.T) {
+	service, _, close := setupServiceWithMock(t)
+	defer close()
+
+	pairStatMap := map[string][countOfStatType]math.LegacyDec{
+		"pair": {
+			statVolume:     math.LegacyNewDec(1000),
+			statCommission: math.LegacyNewDec(7),
+			statLiquidity:  math.LegacyNewDec(0),
+		},
+	}
+
+	stats := service.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod24h])
+	require.Len(t, stats, 1)
+	require.Equal(t, "0", stats[0].AprInPrice, "APR should be 0 when liquidity is 0")
+}

--- a/api/v1/service/stat_test.go
+++ b/api/v1/service/stat_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
@@ -59,4 +60,29 @@ func TestStatService_GetAll_Empty(t *testing.T) {
 	require.Nil(t, actual[Period1mon])
 
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStatService_MapToSlice_AnnualizesAprByPeriod(t *testing.T) {
+	service, _, close := setupServiceWithMock(t)
+	defer close()
+
+	pairStatMap := map[string][countOfStatType]math.LegacyDec{
+		"pair": {
+			statVolume:     math.LegacyNewDec(1000),
+			statCommission: math.LegacyNewDec(7),
+			statLiquidity:  math.LegacyNewDec(100),
+		},
+	}
+
+	stats24h := service.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod24h])
+	require.Len(t, stats24h, 1)
+	require.Equal(t, "2555.000000000000000000", stats24h[0].AprInPrice)
+
+	stats7d := service.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod7d])
+	require.Len(t, stats7d, 1)
+	require.Equal(t, "365.000000000000000000", stats7d[0].AprInPrice)
+
+	stats1mon := service.mapToSlice(pairStatMap, aprAnnualizationByPeriod[statPeriod1mon])
+	require.Len(t, stats1mon, 1)
+	require.Equal(t, "84.000000000000000000", stats1mon[0].AprInPrice)
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dashboard and stats endpoints expose AMM metrics such as APR, TVL, volume, and recent transactions. Some queries either calculated APR as a 7-day fee yield without annualization, used incomplete pool filters for APR volume, or selected inefficient/incorrect inputs for chart and transaction calculations.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR improves dashboard metric correctness and query efficiency.
- Fix APR calculations by annualizing 7-day fee yield with the swap fee rate.
- Scope APR volume queries by chain ID and target pool contract.
- Fix token TVL charts to use `liquidity1_in_price` when the token is `asset1`.
- Push chart bucket filters into the source subqueries before aggregation.
- Simplify transaction price lookups with ordered lateral queries.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected APR/Apr-In-Price calculations to use period-specific annualization (24h, 7d, 1mon).
  * Fixed dashboard APR and “recent” change-rate computations, including safer handling of NULLs and consistent weekly APR basis.
  * Repaired volume/TVL scoping by blockchain to prevent cross-chain contamination and improved token chart correctness.
* **Performance**
  * Streamlined latest (at-or-before) transaction price selection for faster TX value computation.
* **Tests**
  * Expanded dashboard and stat coverage, adding assertions for recent metrics, APR filtering, and TX pricing selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->