### PR TITLE
feat: add mcp resource for service guide

### DIFF
--- a/api/mcpserver/resources.go
+++ b/api/mcpserver/resources.go
@@ -1,0 +1,140 @@
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const resourceMIMETypeMarkdown = "text/markdown"
+
+type resourceSpec struct {
+	URI         string
+	Name        string
+	Title       string
+	Description string
+	MIMEType    string
+	Text        string
+}
+
+func defaultResources() []resourceSpec {
+	return []resourceSpec{
+		{
+			URI:         "dezswap://service/guide",
+			Name:        "dezswap-service-guide",
+			Title:       "Dezswap Service Guide",
+			Description: "Service boundaries and recommended MCP tool usage for Dezswap analytics.",
+			MIMEType:    resourceMIMETypeMarkdown,
+			Text: `# Dezswap Service Guide
+
+This MCP server provides read-only Dezswap analytics and discovery. Use its tools to inspect market data, token metadata, pool state, route availability, charts, recent transactions, health, and version information.
+
+## Boundaries
+
+- The server cannot execute swaps.
+- The server cannot build, sign, or submit transactions.
+- The server cannot return amount-based quotes.
+- The server cannot calculate slippage.
+- The server cannot calculate price impact.
+- The server cannot guarantee route execution.
+
+## Intent-Level Tool Guidance
+
+- For a market overview, use the market overview tool.
+- For token metadata such as symbol, decimals, icon, protocol, or verified status, use the token metadata tool.
+- For token market data such as price, TVL, volume, and fee, use the token market tool.
+- For pools related to a token, use the pool listing tool with the token filter.
+- For route availability, use the route discovery tool.
+- For recent swap, add-liquidity, or remove-liquidity activity, use the recent transactions tool.
+
+## Workflows
+
+- Token basic analysis: get token metadata, then token market data, then related pools.
+- Token trend analysis: only call token chart tools when the user asks for history, trend, or time-series data.
+- Pool basic analysis: get pool metadata, then pool detail.
+- Pool trend analysis: only call pool chart tools when the user asks for history, trend, or time-series data.
+- Route availability: use route discovery and answer only whether a path candidate exists. Do not describe the result as a quote, expected output, execution guarantee, slippage estimate, or price impact estimate.
+
+## Route Caveat
+
+The hopCount argument is a maximum path length filter. It is not a swap amount, quote parameter, slippage setting, or price impact parameter. Do not treat an omitted hopCount as unlimited; set hopCount explicitly when looking for multi-hop routes.
+`,
+		},
+		{
+			URI:         "dezswap://dex/domain-model",
+			Name:        "dezswap-domain-model",
+			Title:       "Dezswap Domain Model",
+			Description: "Dezswap-specific concepts, address conventions, and response interpretation rules.",
+			MIMEType:    resourceMIMETypeMarkdown,
+			Text: `# Dezswap Domain Model
+
+## Core Concepts
+
+- Token: an asset traded or tracked by Dezswap. A token may be a native denom, an IBC denom, a CW20 token, or an ERC20-prefixed asset.
+- Pair: a swap contract connecting two assets, plus a liquidity provider token.
+- Pool: the current liquidity state for a pair, including asset amounts and total share.
+- LP token: the liquidity provider share token for a pair. It is not one of the two swapped assets.
+- Route: a precomputed token path candidate. It is not a quote, transaction, execution guarantee, expected output, slippage estimate, or price impact estimate.
+- Chart: a raw time series with {t, v} items.
+- Transaction action: public transaction action values are swap, add, and remove. The add and remove values correspond to internal provide and withdraw events.
+
+## Address Conventions
+
+- Native assets can look like axpla.
+- IBC assets are stored as ibc/<hash>.
+- For path parameters, encode ibc/<hash> as ibc-<hash> so the slash does not split the URL path.
+- XPLA token identifiers can include prefixed CW20 or ERC20 denom forms.
+
+## Numeric Values
+
+Prices, TVL, volume, fees, liquidity, total share, token amounts, and similar quantities are returned as decimal strings. Do not parse them as binary floating-point values when precision matters.
+
+## Chart Interpretation
+
+- t is a UTC timestamp.
+- v is the raw value for the requested chart type.
+- Chart responses do not include symbol, unit, computed summary, quote, confidence, slippage, or price impact.
+- Use charts only for history or trend questions. They are not needed for basic token or pool analysis.
+
+## Verified Tokens
+
+The verified field means the token matched configured or known asset metadata. It is not investment safety, liquidity quality, route availability, execution success, or price reliability advice.
+`,
+		},
+	}
+}
+
+func addResources(server *mcp.Server) {
+	for _, spec := range defaultResources() {
+		spec := spec
+		server.AddResource(&mcp.Resource{
+			URI:         spec.URI,
+			Name:        spec.Name,
+			Title:       spec.Title,
+			Description: spec.Description,
+			MIMEType:    spec.MIMEType,
+			Size:        int64(len(spec.Text)),
+		}, readStaticResource(spec))
+	}
+}
+
+func readStaticResource(spec resourceSpec) mcp.ResourceHandler {
+	return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		uri := spec.URI
+		if req != nil && req.Params != nil {
+			uri = req.Params.URI
+		}
+		if uri != spec.URI {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{
+				{
+					URI:      spec.URI,
+					MIMEType: spec.MIMEType,
+					Text:     spec.Text,
+				},
+			},
+		}, nil
+	}
+}

--- a/api/mcpserver/server.go
+++ b/api/mcpserver/server.go
@@ -142,6 +142,7 @@ func (s *Server) Mount() {
 			return s.handleTool(ctx, spec, req)
 		})
 	}
+	addResources(server)
 
 	handler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
 		return server

--- a/api/mcpserver/server_test.go
+++ b/api/mcpserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -149,5 +150,88 @@ func TestMCPOriginValidation(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestMCPResources_ListAndRead(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "v0.0.1"}, nil)
+	addResources(server)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server.Connect() error = %v", err)
+	}
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer clientSession.Close()
+
+	resources, err := clientSession.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources() error = %v", err)
+	}
+	if len(resources.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources.Resources))
+	}
+
+	got := map[string]*mcp.Resource{}
+	for _, resource := range resources.Resources {
+		got[resource.URI] = resource
+		if resource.MIMEType != resourceMIMETypeMarkdown {
+			t.Fatalf("expected resource %s MIME type %s, got %s", resource.URI, resourceMIMETypeMarkdown, resource.MIMEType)
+		}
+	}
+	for _, uri := range []string{"dezswap://service/guide", "dezswap://dex/domain-model"} {
+		if _, ok := got[uri]; !ok {
+			t.Fatalf("expected resource %s", uri)
+		}
+	}
+
+	for _, tc := range []struct {
+		uri      string
+		contains []string
+	}{
+		{
+			uri: "dezswap://service/guide",
+			contains: []string{
+				"read-only Dezswap analytics and discovery",
+				"cannot execute swaps",
+				"cannot return amount-based quotes",
+				"cannot calculate slippage",
+				"cannot calculate price impact",
+				"hopCount argument is a maximum path length filter",
+			},
+		},
+		{
+			uri: "dezswap://dex/domain-model",
+			contains: []string{
+				"ibc/<hash>",
+				"ibc-<hash>",
+				"decimal strings",
+				"raw time series with {t, v} items",
+				"not a quote",
+				"public transaction action values are swap, add, and remove",
+			},
+		},
+	} {
+		result, err := clientSession.ReadResource(ctx, &mcp.ReadResourceParams{URI: tc.uri})
+		if err != nil {
+			t.Fatalf("ReadResource(%s) error = %v", tc.uri, err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected one content item for %s, got %d", tc.uri, len(result.Contents))
+		}
+		content := result.Contents[0]
+		if content.MIMEType != resourceMIMETypeMarkdown {
+			t.Fatalf("expected read MIME type %s for %s, got %s", resourceMIMETypeMarkdown, tc.uri, content.MIMEType)
+		}
+		for _, want := range tc.contains {
+			if !strings.Contains(content.Text, want) {
+				t.Fatalf("expected %s to contain %q", tc.uri, want)
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MCP clients can already discover individual Dezswap tools through `tools/list`, but tool descriptions alone do not provide enough service-level context for agents to use the API safely and efficiently.

This change adds lightweight MCP resources that explain Dezswap-specific boundaries, address conventions, DEX domain concepts, and result interpretation rules without duplicating the tool catalog.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added two static English-only MCP resources:
  - `dezswap://service/guide`
  - `dezswap://dex/domain-model`
- Registered the resources on the MCP server alongside the existing tools.
- Documented key agent guidance:
  - The MCP server is read-only analytics/discovery.
  - It does not execute swaps, build/sign transactions, return amount-based quotes, calculate slippage, calculate price impact, or guarantee execution.
  - Route discovery returns path candidates only, not quotes.
  - Chart responses are raw `{t, v}` time series and should only be used for trend/history requests.
  - Decimal values are returned as strings for precision.
  - IBC path parameters should encode `ibc/<hash>` as `ibc-<hash>`.
- Added MCP list/read tests to verify resource exposure, Markdown MIME type, and required domain guidance.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added documentation resources providing comprehensive guides on dezswap services and detailed domain model reference materials. These new resources are now accessible through the platform and improve overall documentation availability, supporting developers with better understanding of available services, capabilities, and system architecture for seamless integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->