### PR TITLE
feat(indexer): support multiple gRPC source nodes for fallback

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -97,8 +97,17 @@ func main() {
 }
 
 func initApp(config configs.IndexerConfig, networkMetadata pkg.NetworkMetadata) (indexer.Indexer, bool) {
-	grpcEndpoint := fmt.Sprintf("%s:%s", config.SrcNode.Host, config.SrcNode.Port)
-	nodeRepo, err := repo.NewNodeRepo(grpcEndpoint, config.SrcEvmRpcEndpoint, config.SrcNode.UseTls, config.ChainId, networkMetadata)
+	grpcEndpoints := []repo.GrpcEndpoint{{Target: fmt.Sprintf("%s:%s", config.SrcNode.Host, config.SrcNode.Port), UseTLS: config.SrcNode.UseTls}}
+	if len(config.SrcNodes) > 0 {
+		grpcEndpoints = make([]repo.GrpcEndpoint, 0, len(config.SrcNodes))
+		for _, node := range config.SrcNodes {
+			grpcEndpoints = append(grpcEndpoints, repo.GrpcEndpoint{
+				Target: fmt.Sprintf("%s:%s", node.Host, node.Port),
+				UseTLS: node.UseTls,
+			})
+		}
+	}
+	nodeRepo, err := repo.NewNodeRepoWithGrpcEndpoints(grpcEndpoints, config.SrcEvmRpcEndpoint, config.ChainId, networkMetadata)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"reflect"
 	"runtime"
@@ -25,7 +24,6 @@ type repeatableJob struct {
 	delay        time.Duration
 	errCount     uint
 	tolerance    uint
-	exponential  bool
 }
 
 func runJob(j *repeatableJob, logger logging.Logger) {
@@ -44,11 +42,6 @@ func runJob(j *repeatableJob, logger logging.Logger) {
 			j.errorHandler(err)
 		}
 
-		wait := j.delay
-		if j.exponential {
-			wait = j.delay * time.Duration(math.Pow(2, float64(j.errCount)))
-		}
-		time.Sleep(wait)
 	} else {
 		j.errCount = 0
 	}
@@ -71,8 +64,8 @@ func main() {
 
 	app, hasAssetRepo := initApp(c.Indexer, networkMetadata)
 	jobs := []*repeatableJob{
-		{each: app.UpdateTokens, errorHandler: nil, delay: time.Duration(networkMetadata.BlockSecond) * time.Second, errCount: 0, tolerance: 3, exponential: true},
-		{each: app.UpdateLatestPools, errorHandler: nil, delay: time.Duration(networkMetadata.BlockSecond) * time.Second, errCount: 0, tolerance: 3, exponential: true},
+		{each: app.UpdateTokens, errorHandler: nil, delay: time.Duration(networkMetadata.BlockSecond) * time.Second, errCount: 0, tolerance: 3},
+		{each: app.UpdateLatestPools, errorHandler: nil, delay: time.Duration(networkMetadata.BlockSecond) * time.Second, errCount: 0, tolerance: 3},
 	}
 	// indexer.UpdateVerifiedTokens can run only when assetRepo exists
 	if hasAssetRepo {
@@ -84,7 +77,6 @@ func main() {
 				delay:        time.Duration(networkMetadata.BlockSecond) * time.Second,
 				errCount:     0,
 				tolerance:    3,
-				exponential:  true,
 			},
 		)
 	}

--- a/config.example.yml
+++ b/config.example.yml
@@ -4,6 +4,12 @@ indexer:
     host: 10.0.0.1
     port: 9090
     factory:
+  # Optional fallback candidates. When set, indexer selects the first
+  # responding node at the start of each job.
+  # src_nodes:
+  #   - host: 10.0.0.1
+  #     port: 9090
+  #     use_tls: false
   src_evm_rpc_endpoint: "http://10.0.0.1:8545"
   src_db:
     host: localhost

--- a/configs/grpc.config.go
+++ b/configs/grpc.config.go
@@ -8,9 +8,9 @@ import (
 )
 
 type GrpcConfig struct {
-	Host   string
-	Port   string
-	UseTls bool
+	Host   string `mapstructure:"host"`
+	Port   string `mapstructure:"port"`
+	UseTls bool   `mapstructure:"use_tls"`
 }
 
 func (lhs *GrpcConfig) Override(rhs GrpcConfig) {
@@ -23,6 +23,10 @@ func (lhs *GrpcConfig) Override(rhs GrpcConfig) {
 	if rhs.UseTls {
 		lhs.UseTls = rhs.UseTls
 	}
+}
+
+func (lhs GrpcConfig) IsZero() bool {
+	return lhs.Host == "" && lhs.Port == "" && !lhs.UseTls
 }
 
 func grpcConfig(v *viper.Viper) GrpcConfig {
@@ -45,4 +49,16 @@ func grpcConfigFromEnv(v *viper.Viper, prefix string) GrpcConfig {
 		Port:   v.GetString(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "port"))),
 		UseTls: v.GetBool(strings.ToUpper(fmt.Sprintf("%s_%s", prefix, "use_tls"))),
 	}
+}
+
+func grpcConfigs(v *viper.Viper, key string) []GrpcConfig {
+	if v == nil {
+		return nil
+	}
+
+	var configs []GrpcConfig
+	if err := v.UnmarshalKey(key, &configs); err != nil {
+		return nil
+	}
+	return configs
 }

--- a/configs/grpc.config.go
+++ b/configs/grpc.config.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -8,9 +9,9 @@ import (
 )
 
 type GrpcConfig struct {
-	Host   string `mapstructure:"host"`
-	Port   string `mapstructure:"port"`
-	UseTls bool   `mapstructure:"use_tls"`
+	Host   string `mapstructure:"host" json:"host"`
+	Port   string `mapstructure:"port" json:"port"`
+	UseTls bool   `mapstructure:"use_tls" json:"use_tls"`
 }
 
 func (lhs *GrpcConfig) Override(rhs GrpcConfig) {
@@ -51,14 +52,31 @@ func grpcConfigFromEnv(v *viper.Viper, prefix string) GrpcConfig {
 	}
 }
 
-func grpcConfigs(v *viper.Viper, key string) []GrpcConfig {
+func grpcConfigs(v *viper.Viper, key string) ([]GrpcConfig, error) {
 	if v == nil {
-		return nil
+		return nil, nil
 	}
 
 	var configs []GrpcConfig
 	if err := v.UnmarshalKey(key, &configs); err != nil {
-		return nil
+		return nil, fmt.Errorf("unmarshal %s: %w", key, err)
 	}
-	return configs
+	return configs, nil
+}
+
+func grpcConfigsFromEnv(v *viper.Viper, prefix string) ([]GrpcConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	value := v.GetString(strings.ToUpper(prefix))
+	if value == "" {
+		return nil, nil
+	}
+
+	var configs []GrpcConfig
+	if err := json.Unmarshal([]byte(value), &configs); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", strings.ToUpper(prefix), err)
+	}
+	return configs, nil
 }

--- a/configs/indexer.go
+++ b/configs/indexer.go
@@ -7,6 +7,7 @@ import (
 type IndexerConfig struct {
 	ChainId           string
 	SrcNode           GrpcConfig
+	SrcNodes          []GrpcConfig
 	SrcEvmRpcEndpoint string
 	SrcDb             RdbConfig
 	Db                RdbConfig
@@ -22,7 +23,11 @@ func indexerConfig(v *viper.Viper) IndexerConfig {
 
 	nodeC := grpcConfig(v.Sub("indexer.src_node"))
 	envNodeC := grpcConfigFromEnv(v, "INDEXER_SRC_NODE")
+	nodeCs := grpcConfigs(v, "indexer.src_nodes")
 	nodeC.Override(envNodeC)
+	if !envNodeC.IsZero() {
+		nodeCs = nil
+	}
 
 	srcEvmRpcEndpoint := v.GetString("indexer.src_evm_rpc_endpoint")
 	envSrcEvmRpcEndpoint := v.GetString("INDEXER_SRC_EVM_RPC_ENDPOINT")
@@ -47,6 +52,7 @@ func indexerConfig(v *viper.Viper) IndexerConfig {
 	return IndexerConfig{
 		ChainId:           chainId,
 		SrcNode:           nodeC,
+		SrcNodes:          nodeCs,
 		SrcEvmRpcEndpoint: srcEvmRpcEndpoint,
 		SrcDb:             srcDbC,
 		Db:                dbC,

--- a/configs/indexer.go
+++ b/configs/indexer.go
@@ -23,7 +23,17 @@ func indexerConfig(v *viper.Viper) IndexerConfig {
 
 	nodeC := grpcConfig(v.Sub("indexer.src_node"))
 	envNodeC := grpcConfigFromEnv(v, "INDEXER_SRC_NODE")
-	nodeCs := grpcConfigs(v, "indexer.src_nodes")
+	envNodeCs, err := grpcConfigsFromEnv(v, "INDEXER_SRC_NODES")
+	if err != nil {
+		panic(err)
+	}
+	nodeCs := envNodeCs
+	if len(nodeCs) == 0 {
+		nodeCs, err = grpcConfigs(v, "indexer.src_nodes")
+		if err != nil {
+			panic(err)
+		}
+	}
 	nodeC.Override(envNodeC)
 	if !envNodeC.IsZero() {
 		nodeCs = nil

--- a/configs/indexer_test.go
+++ b/configs/indexer_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"os"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -40,6 +41,28 @@ func TestIndexerConfigSrcNodes(t *testing.T) {
 	require.Equal(t, GrpcConfig{Host: "candidate-2.example.com", Port: "9090", UseTls: false}, c.SrcNodes[1])
 }
 
+func TestIndexerConfigSrcNodesOverrideByEnv(t *testing.T) {
+	const envKey = "APP_INDEXER_SRC_NODES"
+	require.NoError(t, os.Setenv(envKey, `[{"host":"env-1.example.com","port":"443","use_tls":true},{"host":"env-2.example.com","port":"9090","use_tls":false}]`))
+	defer os.Unsetenv(envKey)
+
+	v := newTestViper(t, `
+indexer:
+  chain_id: dorado-1
+  src_nodes:
+    - host: candidate-1.example.com
+      port: "443"
+      use_tls: true
+`)
+
+	c := indexerConfig(v)
+
+	require.Equal(t, []GrpcConfig{
+		{Host: "env-1.example.com", Port: "443", UseTls: true},
+		{Host: "env-2.example.com", Port: "9090", UseTls: false},
+	}, c.SrcNodes)
+}
+
 func TestIndexerConfigEnvSrcNodeOverrideDisablesSrcNodes(t *testing.T) {
 	v := viper.New()
 	v.Set("indexer.chain_id", "dorado-1")
@@ -58,4 +81,31 @@ func TestIndexerConfigEnvSrcNodeOverrideDisablesSrcNodes(t *testing.T) {
 	require.Equal(t, "8443", c.SrcNode.Port)
 	require.True(t, c.SrcNode.UseTls)
 	require.Empty(t, c.SrcNodes)
+}
+
+func TestIndexerConfigSrcNodesEnvUnmarshalErrorPanics(t *testing.T) {
+	const envKey = "APP_INDEXER_SRC_NODES"
+	require.NoError(t, os.Setenv(envKey, `not-json`))
+	defer os.Unsetenv(envKey)
+
+	v := newTestViper(t, `
+indexer:
+  chain_id: dorado-1
+`)
+
+	require.Panics(t, func() {
+		indexerConfig(v)
+	})
+}
+
+func TestIndexerConfigSrcNodesUnmarshalErrorPanics(t *testing.T) {
+	v := viper.New()
+	v.Set("indexer.chain_id", "dorado-1")
+	v.Set("indexer.src_nodes", []map[string]interface{}{
+		{"host": []string{"candidate.example.com"}, "port": "443", "use_tls": true},
+	})
+
+	require.Panics(t, func() {
+		indexerConfig(v)
+	})
 }

--- a/configs/indexer_test.go
+++ b/configs/indexer_test.go
@@ -1,0 +1,61 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexerConfigSrcNodeBackwardCompatibility(t *testing.T) {
+	v := viper.New()
+	v.Set("indexer.chain_id", "dorado-1")
+	v.Set("indexer.src_node.host", "primary.example.com")
+	v.Set("indexer.src_node.port", "443")
+	v.Set("indexer.src_node.use_tls", true)
+
+	c := indexerConfig(v)
+
+	require.Equal(t, "primary.example.com", c.SrcNode.Host)
+	require.Equal(t, "443", c.SrcNode.Port)
+	require.True(t, c.SrcNode.UseTls)
+	require.Empty(t, c.SrcNodes)
+}
+
+func TestIndexerConfigSrcNodes(t *testing.T) {
+	v := viper.New()
+	v.Set("indexer.chain_id", "dorado-1")
+	v.Set("indexer.src_node.host", "primary.example.com")
+	v.Set("indexer.src_node.port", "443")
+	v.Set("indexer.src_node.use_tls", true)
+	v.Set("indexer.src_nodes", []map[string]interface{}{
+		{"host": "candidate-1.example.com", "port": "443", "use_tls": true},
+		{"host": "candidate-2.example.com", "port": "9090", "use_tls": false},
+	})
+
+	c := indexerConfig(v)
+
+	require.Len(t, c.SrcNodes, 2)
+	require.Equal(t, GrpcConfig{Host: "candidate-1.example.com", Port: "443", UseTls: true}, c.SrcNodes[0])
+	require.Equal(t, GrpcConfig{Host: "candidate-2.example.com", Port: "9090", UseTls: false}, c.SrcNodes[1])
+}
+
+func TestIndexerConfigEnvSrcNodeOverrideDisablesSrcNodes(t *testing.T) {
+	v := viper.New()
+	v.Set("indexer.chain_id", "dorado-1")
+	v.Set("indexer.src_node.host", "primary.example.com")
+	v.Set("indexer.src_node.port", "443")
+	v.Set("indexer.src_node.use_tls", true)
+	v.Set("indexer.src_nodes", []map[string]interface{}{
+		{"host": "candidate-1.example.com", "port": "443", "use_tls": true},
+	})
+	v.Set("INDEXER_SRC_NODE_HOST", "env.example.com")
+	v.Set("INDEXER_SRC_NODE_PORT", "8443")
+
+	c := indexerConfig(v)
+
+	require.Equal(t, "env.example.com", c.SrcNode.Host)
+	require.Equal(t, "8443", c.SrcNode.Port)
+	require.True(t, c.SrcNode.UseTls)
+	require.Empty(t, c.SrcNodes)
+}

--- a/indexer/repo/node.repo.go
+++ b/indexer/repo/node.repo.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 
+	ibc_types "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	"github.com/dezswap/dezswap-api/indexer"
 	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/dezswap/dezswap-api/pkg/dezswap"
@@ -11,7 +12,7 @@ import (
 
 type nodeRepoImpl struct {
 	pkg.EthClient
-	pkg.GrpcClient
+	grpcClients []pkg.GrpcClient
 	nodeMapper
 	pkg.NetworkMetadata
 	chainId string
@@ -19,41 +20,66 @@ type nodeRepoImpl struct {
 
 var _ indexer.NodeRepo = &nodeRepoImpl{}
 
+type GrpcEndpoint struct {
+	Target string
+	UseTLS bool
+}
+
 func NewNodeRepo(grpcEndpoint, ethRpcEndpoint string, useTls bool, chainId string, networkMetadata pkg.NetworkMetadata) (indexer.NodeRepo, error) {
-	grpcClient, err := pkg.NewGrpcClient(grpcEndpoint, useTls)
-	if err != nil {
-		return nil, err
+	return NewNodeRepoWithGrpcEndpoints([]GrpcEndpoint{{Target: grpcEndpoint, UseTLS: useTls}}, ethRpcEndpoint, chainId, networkMetadata)
+}
+
+func NewNodeRepoWithGrpcEndpoints(grpcEndpoints []GrpcEndpoint, ethRpcEndpoint string, chainId string, networkMetadata pkg.NetworkMetadata) (indexer.NodeRepo, error) {
+	if len(grpcEndpoints) == 0 {
+		return nil, errors.New("NewNodeRepoWithGrpcEndpoints: grpc endpoint is not configured")
+	}
+
+	grpcClients := make([]pkg.GrpcClient, 0, len(grpcEndpoints))
+	for i, endpoint := range grpcEndpoints {
+		grpcClient, err := pkg.NewGrpcClient(endpoint.Target, endpoint.UseTLS)
+		if err != nil {
+			return nil, errors.Wrapf(err, "NewNodeRepoWithGrpcEndpoints: failed to create grpc client endpoint[%d]=%s", i, endpoint.Target)
+		}
+		grpcClients = append(grpcClients, grpcClient)
 	}
 
 	var ethClient pkg.EthClient
+	var err error
 	if ethRpcEndpoint != "" {
 		ethClient, err = pkg.NewEthClient(ethRpcEndpoint)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "NewNodeRepoWithGrpcEndpoints: failed to create eth client endpoint=%s", ethRpcEndpoint)
 		}
 	}
 
 	return &nodeRepoImpl{
-		ethClient,
-		grpcClient,
-		&nodeMapperImpl{},
-		networkMetadata,
-		chainId,
+		EthClient:       ethClient,
+		grpcClients:     grpcClients,
+		nodeMapper:      &nodeMapperImpl{},
+		NetworkMetadata: networkMetadata,
+		chainId:         chainId,
 	}, nil
 }
 
 // LatestHeightFromNode implements NodeRepo
 func (r *nodeRepoImpl) LatestHeightFromNode() (uint64, error) {
-	height, err := r.SyncedHeight()
-	if err != nil {
-		return 0, errors.Wrap(err, "nodeRepoImpl.HeightFromNode")
+	var lastErr error
+	for _, client := range r.grpcClients {
+		height, err := client.SyncedHeight()
+		if err == nil {
+			return height, nil
+		}
+		lastErr = err
 	}
-	return height, nil
+	if lastErr != nil {
+		return 0, errors.Wrap(lastErr, "nodeRepoImpl.HeightFromNode")
+	}
+	return 0, errors.New("nodeRepoImpl.HeightFromNode: grpc client is not configured")
 }
 
 // PoolFromNode implements NodeRepo
 func (r *nodeRepoImpl) PoolFromNode(addr string, height uint64) (*indexer.PoolInfo, error) {
-	res, err := r.QueryContract(addr, dezswap.QUERY_POOL, height)
+	res, err := r.queryContractFromNode(addr, dezswap.QUERY_POOL, height)
 	if err != nil {
 		return nil, errors.Wrap(err, "nodeRepoImpl.PoolFromNode")
 	}
@@ -93,7 +119,7 @@ func (r *nodeRepoImpl) denomFromNode(addr string) (*indexer.Token, error) {
 }
 
 func (r *nodeRepoImpl) ibcFromNode(addr string) (*indexer.Token, error) {
-	trace, err := r.QueryIbcDenomTrace(addr)
+	trace, err := r.ibcDenomTraceFromNode(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "nodeRepoImpl.cw20FromNode")
 	}
@@ -112,7 +138,7 @@ func (r *nodeRepoImpl) ibcFromNode(addr string) (*indexer.Token, error) {
 func (r *nodeRepoImpl) cw20FromNode(addr string) (*indexer.Token, error) {
 	trimmedAddr := r.TrimDenomPrefix(addr) // in case of xcw20: address
 
-	res, err := r.QueryContract(trimmedAddr, dezswap.QUERY_TOKEN, r.LatestHeightIndicator)
+	res, err := r.queryContractFromNode(trimmedAddr, dezswap.QUERY_TOKEN, r.LatestHeightIndicator)
 	if err != nil {
 		return nil, errors.Wrap(err, "nodeRepoImpl.cw20FromNode")
 	}
@@ -127,6 +153,36 @@ func (r *nodeRepoImpl) cw20FromNode(addr string) (*indexer.Token, error) {
 	token.Address = addr
 	token.ChainId = r.chainId
 	return token, nil
+}
+
+func (r *nodeRepoImpl) queryContractFromNode(addr string, query []byte, height uint64) ([]byte, error) {
+	var lastErr error
+	for _, client := range r.grpcClients {
+		res, err := client.QueryContract(addr, query, height)
+		if err == nil {
+			return res, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New("nodeRepoImpl.QueryContractFromNode: grpc client is not configured")
+}
+
+func (r *nodeRepoImpl) ibcDenomTraceFromNode(addr string) (*ibc_types.Denom, error) {
+	var lastErr error
+	for _, client := range r.grpcClients {
+		trace, err := client.QueryIbcDenomTrace(addr)
+		if err == nil {
+			return trace, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, errors.New("nodeRepoImpl.QueryIbcDenomTraceFromNode: grpc client is not configured")
 }
 
 func (r *nodeRepoImpl) erc20FromNode(addr string) (*indexer.Token, error) {

--- a/indexer/repo/node.repo.go
+++ b/indexer/repo/node.repo.go
@@ -2,15 +2,12 @@ package repo
 
 import (
 	"context"
-	"time"
 
 	"github.com/dezswap/dezswap-api/indexer"
 	"github.com/dezswap/dezswap-api/pkg"
 	"github.com/dezswap/dezswap-api/pkg/dezswap"
 	"github.com/pkg/errors"
 )
-
-const queryTimeout = 5 * time.Second
 
 type nodeRepoImpl struct {
 	pkg.EthClient
@@ -138,7 +135,7 @@ func (r *nodeRepoImpl) erc20FromNode(addr string) (*indexer.Token, error) {
 	}
 
 	trimmedAddr := r.TrimDenomPrefix(addr)
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), pkg.NodeQueryTimeout)
 	defer cancel()
 
 	erc20Meta, err := r.QueryErc20Info(ctx, trimmedAddr)

--- a/indexer/repo/node.repo_test.go
+++ b/indexer/repo/node.repo_test.go
@@ -65,7 +65,13 @@ func (s *nodeRepoSuite) SetupSuite() {
 		"",
 		"",
 	)
-	s.r = nodeRepoImpl{s.ethClient, s.client, &nodeMapperImpl{}, s.networkMetadata, s.chainId}
+	s.r = nodeRepoImpl{
+		EthClient:       s.ethClient,
+		grpcClients:     []pkg.GrpcClient{s.client},
+		nodeMapper:      &nodeMapperImpl{},
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
 }
 
 func (s *nodeRepoSuite) Test_LatestHeightFromNode() {
@@ -87,6 +93,142 @@ func (s *nodeRepoSuite) Test_LatestHeightFromNode() {
 			assert.Equal(s.T(), tc.expected, actual)
 		}
 	}
+}
+
+func (s *nodeRepoSuite) Test_LatestHeightFromNode_SelectsNextClientOnFailure() {
+	firstClient := xpla_mock.NewGrpcClientMock()
+	secondClient := xpla_mock.NewGrpcClientMock()
+	r := nodeRepoImpl{
+		grpcClients:     []pkg.GrpcClient{firstClient, secondClient},
+		nodeMapper:      &nodeMapperImpl{},
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
+
+	firstClient.On("SyncedHeight").Return(uint64(0), errors.New("unavailable")).Once()
+	secondClient.On("SyncedHeight").Return(uint64(100), nil).Once()
+
+	height, err := r.LatestHeightFromNode()
+
+	s.Require().NoError(err)
+	s.Equal(uint64(100), height)
+	firstClient.AssertExpectations(s.T())
+	secondClient.AssertExpectations(s.T())
+}
+
+func (s *nodeRepoSuite) Test_PoolFromNode_SelectsNextClientOnFailure() {
+	firstClient := xpla_mock.NewGrpcClientMock()
+	secondClient := xpla_mock.NewGrpcClientMock()
+	mapperMock := &nodeMapperMock{}
+	r := nodeRepoImpl{
+		grpcClients:     []pkg.GrpcClient{firstClient, secondClient},
+		nodeMapper:      mapperMock,
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
+
+	const addr = "xpla1pool"
+	const height = uint64(100)
+	dummyRes := []byte(`{}`)
+	expected := &indexer.PoolInfo{Address: addr, Height: height}
+
+	firstClient.On("QueryContract", addr, dezswap.QUERY_POOL, height).Return([]byte(nil), errors.New("unavailable")).Once()
+	secondClient.On("QueryContract", addr, dezswap.QUERY_POOL, height).Return(dummyRes, nil).Once()
+	mapperMock.On("resToPoolInfo", addr, s.chainId, height, dummyRes).Return(expected, nil).Once()
+
+	actual, err := r.PoolFromNode(addr, height)
+
+	s.Require().NoError(err)
+	s.Equal(expected, actual)
+	firstClient.AssertExpectations(s.T())
+	secondClient.AssertExpectations(s.T())
+	mapperMock.AssertExpectations(s.T())
+}
+
+func (s *nodeRepoSuite) Test_PoolFromNode_ReturnsLastErrorWhenAllClientsFail() {
+	firstClient := xpla_mock.NewGrpcClientMock()
+	secondClient := xpla_mock.NewGrpcClientMock()
+	mapperMock := &nodeMapperMock{}
+	r := nodeRepoImpl{
+		grpcClients:     []pkg.GrpcClient{firstClient, secondClient},
+		nodeMapper:      mapperMock,
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
+
+	const addr = "xpla1pool"
+	const height = uint64(100)
+
+	firstClient.On("QueryContract", addr, dezswap.QUERY_POOL, height).Return([]byte(nil), errors.New("unavailable")).Once()
+	secondClient.On("QueryContract", addr, dezswap.QUERY_POOL, height).Return([]byte(nil), errors.New("connection reset")).Once()
+
+	actual, err := r.PoolFromNode(addr, height)
+
+	s.Require().Error(err)
+	s.Nil(actual)
+	s.Contains(err.Error(), "connection reset")
+	mapperMock.AssertNotCalled(s.T(), "resToPoolInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	firstClient.AssertExpectations(s.T())
+	secondClient.AssertExpectations(s.T())
+}
+
+func (s *nodeRepoSuite) Test_cw20FromNode_SelectsNextClientOnFailure() {
+	firstClient := xpla_mock.NewGrpcClientMock()
+	secondClient := xpla_mock.NewGrpcClientMock()
+	mapperMock := &nodeMapperMock{}
+	r := nodeRepoImpl{
+		grpcClients:     []pkg.GrpcClient{firstClient, secondClient},
+		nodeMapper:      mapperMock,
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
+
+	const addr = "xpla1abc"
+	dummyRes := []byte(`{}`)
+	expected := &indexer.Token{Symbol: "TEST", Name: "Test Token", Decimals: 6}
+
+	firstClient.On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return([]byte(nil), errors.New("unavailable")).Once()
+	secondClient.On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return(dummyRes, nil).Once()
+	mapperMock.On("resToToken", addr, s.chainId, dummyRes).Return(expected, nil).Once()
+
+	token, err := r.cw20FromNode(addr)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(token)
+	s.Equal(addr, token.Address)
+	s.Equal(s.chainId, token.ChainId)
+	s.Equal("TEST", token.Symbol)
+	firstClient.AssertExpectations(s.T())
+	secondClient.AssertExpectations(s.T())
+	mapperMock.AssertExpectations(s.T())
+}
+
+func (s *nodeRepoSuite) Test_ibcFromNode_SelectsNextClientOnFailure() {
+	firstClient := xpla_mock.NewGrpcClientMock()
+	secondClient := xpla_mock.NewGrpcClientMock()
+	mapperMock := &nodeMapperMock{}
+	r := nodeRepoImpl{
+		grpcClients:     []pkg.GrpcClient{firstClient, secondClient},
+		nodeMapper:      mapperMock,
+		NetworkMetadata: s.networkMetadata,
+		chainId:         s.chainId,
+	}
+
+	const addr = "ibc/ABC"
+	trace := &ibc_types.Denom{Base: "uxpla"}
+	expected := &indexer.Token{Address: addr, Symbol: "XPLA", Name: "XPLA", Decimals: 18}
+
+	firstClient.On("QueryIbcDenomTrace", addr).Return((*ibc_types.Denom)(nil), errors.New("unavailable")).Once()
+	secondClient.On("QueryIbcDenomTrace", addr).Return(trace, nil).Once()
+	mapperMock.On("denomTraceToToken", addr, s.chainId, trace).Return(expected, nil).Once()
+
+	token, err := r.ibcFromNode(addr)
+
+	s.Require().NoError(err)
+	s.Equal(expected, token)
+	firstClient.AssertExpectations(s.T())
+	secondClient.AssertExpectations(s.T())
+	mapperMock.AssertExpectations(s.T())
 }
 
 func (s *nodeRepoSuite) Test_TokenFromNode() {
@@ -177,11 +319,18 @@ func (s *nodeRepoSuite) Test_cw20FromNode() {
 
 	for _, tc := range tcs {
 		s.Run(tc.name, func() {
+			client := xpla_mock.NewGrpcClientMock()
 			mapperMock := &nodeMapperMock{}
-			r := nodeRepoImpl{s.ethClient, s.client, mapperMock, s.networkMetadata, s.chainId}
+			r := nodeRepoImpl{
+				EthClient:       s.ethClient,
+				grpcClients:     []pkg.GrpcClient{client},
+				nodeMapper:      mapperMock,
+				NetworkMetadata: s.networkMetadata,
+				chainId:         s.chainId,
+			}
 
-			s.client.(*xpla_mock.GrpcClientMock).On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return(dummyRes, nil).Once()
-			
+			client.On("QueryContract", addr, dezswap.QUERY_TOKEN, s.networkMetadata.LatestHeightIndicator).Return(dummyRes, nil).Once()
+
 			var mockToken *indexer.Token
 			if tc.expectErr == "" {
 				mockToken = &indexer.Token{Symbol: "TEST", Name: "Test Token", Decimals: 6}
@@ -199,6 +348,8 @@ func (s *nodeRepoSuite) Test_cw20FromNode() {
 				s.Equal(s.chainId, token.ChainId)
 				s.Equal("TEST", token.Symbol)
 			}
+			client.AssertExpectations(s.T())
+			mapperMock.AssertExpectations(s.T())
 		})
 	}
 }

--- a/pkg/grpc.go
+++ b/pkg/grpc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strconv"
+	"time"
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -29,6 +30,8 @@ type grpcClient struct {
 
 var _ GrpcClient = &grpcClient{}
 
+const NodeQueryTimeout = 5 * time.Second
+
 func NewGrpcClient(target string, useTls bool) (GrpcClient, error) {
 	var cred credentials.TransportCredentials
 	if useTls {
@@ -48,9 +51,11 @@ func NewGrpcClient(target string, useTls bool) (GrpcClient, error) {
 // SyncedHeight implements GrpcClient
 func (c *grpcClient) SyncedHeight() (uint64, error) {
 	client := cmtservice.NewServiceClient(c)
+	ctx, cancel := context.WithTimeout(context.Background(), NodeQueryTimeout)
+	defer cancel()
 
 	// Get the latest block height
-	res, err := client.GetLatestBlock(context.Background(), &cmtservice.GetLatestBlockRequest{})
+	res, err := client.GetLatestBlock(ctx, &cmtservice.GetLatestBlockRequest{})
 	if err != nil {
 		fmt.Printf("failed to get latest block height: %v\n", err)
 		return 0, err
@@ -72,6 +77,8 @@ func (c *grpcClient) QueryContract(addr string, query []byte, height uint64) ([]
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, cosmos_types.GRPCBlockHeightHeader, strconv.FormatUint(height, 10))
 	}
+	ctx, cancel := context.WithTimeout(ctx, NodeQueryTimeout)
+	defer cancel()
 
 	res, err := client.SmartContractState(ctx, &cosmwasm_types.QuerySmartContractStateRequest{Address: addr, QueryData: query})
 	if err != nil {
@@ -84,7 +91,8 @@ func (c *grpcClient) QueryContract(addr string, query []byte, height uint64) ([]
 // QueryIbcDenomTrace implements GrpcClient
 func (c *grpcClient) QueryIbcDenomTrace(addr string) (*ibc_types.Denom, error) {
 	client := ibc_types.NewQueryClient(c)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), NodeQueryTimeout)
+	defer cancel()
 
 	res, err := client.Denom(ctx, &ibc_types.QueryDenomRequest{Hash: addr})
 	if err != nil {

--- a/pkg/xpla/mock/mocks.go
+++ b/pkg/xpla/mock/mocks.go
@@ -32,7 +32,7 @@ func (g *GrpcClientMock) SyncedHeight() (uint64, error) {
 
 // QueryIbcDenomTrace implements pkg.GrpcClient
 func (g *GrpcClientMock) QueryIbcDenomTrace(hash string) (*ibctypes.Denom, error) {
-	args := g.MethodCalled("QueryIbcDenomTrace")
+	args := g.MethodCalled("QueryIbcDenomTrace", hash)
 	return args.Get(0).(*ibctypes.Denom), args.Error(1)
 }
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The indexer currently depends on a single configured gRPC source node. If that public node intermittently resets connections or becomes unavailable, node queries can fail until the next scheduled job.

The previous job-level exponential sleep also delayed recovery even though the indexer job already runs on a short block-based interval.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR improves indexer node query resilience.
- Add a shared `NodeQueryTimeout` and apply it to gRPC node queries:
  - latest height query
  - CosmWasm contract query
  - IBC denom trace query
  - ERC20 metadata query
- Remove exponential sleep from indexer job error handling.
- Add optional `indexer.src_nodes` config for multiple gRPC source nodes.
- Keep existing `indexer.src_node` config and `APP_INDEXER_SRC_NODE_*` env override behavior backward compatible.
- Add fallback behavior across configured gRPC clients for node queries.
- Add tests for config parsing and multi-node fallback behavior.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The indexer can now use multiple source nodes and automatically fall back to the first responsive one.

* **Bug Fixes**
  * Improved resilience when a source node is unavailable by trying additional nodes before failing.
  * Added timeouts to chain queries to avoid hanging requests and improve reliability.

* **Documentation**
  * Updated the sample configuration to show the new optional multi-node setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->