### PR TITLE
chore: use AppVersion for MCP server metadata

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -75,7 +75,7 @@ func RunServer(c configs.Config, cache cache.Cache, db *gorm.DB) {
 		app.engine.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	}
 
-	if err := mcpserver.Mount(app.engine, c.Api.MCP); err != nil {
+	if err := mcpserver.Mount(app.engine, c.Api.MCP, AppVersion); err != nil {
 		panic(err)
 	}
 

--- a/api/mcpserver/server.go
+++ b/api/mcpserver/server.go
@@ -32,6 +32,7 @@ type Config = configs.ApiMCPConfig
 type Server struct {
 	engine           *gin.Engine
 	config           Config
+	version          string
 	tools            []toolSpec
 	toolByName       map[string]toolSpec
 	requestTimeout   time.Duration
@@ -56,9 +57,13 @@ type paramSpec struct {
 	Enum        []string
 }
 
-// New creates an MCP server backed by the given Gin engine.
-func New(engine *gin.Engine, cfg Config) (*Server, error) {
+// New creates an MCP server backed by the given Gin engine and service version.
+func New(engine *gin.Engine, cfg Config, version string) (*Server, error) {
 	cfg = withDefaults(cfg)
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil, errors.New("MCP server version is required")
+	}
 	tools := defaultTools()
 	if len(cfg.IncludeOperations) > 0 {
 		allowed, err := validateIncludedOperations(tools, cfg.IncludeOperations)
@@ -86,6 +91,7 @@ func New(engine *gin.Engine, cfg Config) (*Server, error) {
 	return &Server{
 		engine:           engine,
 		config:           cfg,
+		version:          version,
 		tools:            tools,
 		toolByName:       toolByName,
 		requestTimeout:   time.Duration(cfg.RequestTimeoutMs) * time.Millisecond,
@@ -109,12 +115,12 @@ func validateIncludedOperations(tools []toolSpec, operations []string) (map[stri
 	return allowed, nil
 }
 
-// Mount attaches the MCP endpoint when it is enabled.
-func Mount(engine *gin.Engine, cfg Config) error {
+// Mount attaches the MCP endpoint with the given service version when it is enabled.
+func Mount(engine *gin.Engine, cfg Config, version string) error {
 	if !cfg.Enabled {
 		return nil
 	}
-	srv, err := New(engine, cfg)
+	srv, err := New(engine, cfg, version)
 	if err != nil {
 		return err
 	}
@@ -124,25 +130,7 @@ func Mount(engine *gin.Engine, cfg Config) error {
 
 // Mount registers the streamable HTTP MCP handler.
 func (s *Server) Mount() {
-	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "dezswap-api",
-		Version: "v1",
-	}, &mcp.ServerOptions{
-		Instructions: "Read-only Dezswap DEX analytics and discovery tools. These tools do not execute swaps, build transactions, or provide amount-based quotes/slippage.",
-	})
-
-	for _, spec := range s.tools {
-		spec := spec
-		server.AddTool(&mcp.Tool{
-			Name:        spec.Name,
-			Title:       spec.Title,
-			Description: spec.Description,
-			InputSchema: inputSchema(spec),
-		}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return s.handleTool(ctx, spec, req)
-		})
-	}
-	addResources(server)
+	server := s.newMCPServer()
 
 	handler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
 		return server
@@ -162,6 +150,29 @@ func (s *Server) Mount() {
 		s.setCORSHeaders(c)
 		handler.ServeHTTP(c.Writer, c.Request)
 	})
+}
+
+func (s *Server) newMCPServer() *mcp.Server {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "dezswap-api",
+		Version: s.version,
+	}, &mcp.ServerOptions{
+		Instructions: "Read-only Dezswap DEX analytics and discovery tools. These tools do not execute swaps, build transactions, or provide amount-based quotes/slippage.",
+	})
+
+	for _, spec := range s.tools {
+		spec := spec
+		server.AddTool(&mcp.Tool{
+			Name:        spec.Name,
+			Title:       spec.Title,
+			Description: spec.Description,
+			InputSchema: inputSchema(spec),
+		}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return s.handleTool(ctx, spec, req)
+		})
+	}
+	addResources(server)
+	return server
 }
 
 // handleTool validates arguments and dispatches one MCP tool call.

--- a/api/mcpserver/server_test.go
+++ b/api/mcpserver/server_test.go
@@ -16,7 +16,7 @@ func TestNew_FiltersIncludedOperations(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	server, err := New(gin.New(), Config{
 		IncludeOperations: []string{"get_service_version", "find_routes"},
-	})
+	}, "test")
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -35,9 +35,53 @@ func TestNew_RejectsUnknownIncludedOperation(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	_, err := New(gin.New(), Config{
 		IncludeOperations: []string{"get_service_version", "missing_operation"},
-	})
+	}, "test")
 	if err == nil {
 		t.Fatal("expected unknown included operation error")
+	}
+}
+
+func TestNew_RejectsEmptyVersion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, err := New(gin.New(), Config{
+		IncludeOperations: []string{"get_service_version"},
+	}, " ")
+	if err == nil {
+		t.Fatal("expected empty version error")
+	}
+	if err.Error() != "MCP server version is required" {
+		t.Fatalf("expected version required error, got %q", err.Error())
+	}
+}
+
+func TestNew_UsesServiceVersionAsMCPServerInfo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx := context.Background()
+	server, err := New(gin.New(), Config{
+		IncludeOperations: []string{"get_service_version"},
+	}, "v1.2.3")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	mcpServer := server.newMCPServer()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := mcpServer.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server.Connect() error = %v", err)
+	}
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer clientSession.Close()
+
+	serverInfo := clientSession.InitializeResult().ServerInfo
+	if serverInfo.Name != "dezswap-api" {
+		t.Fatalf("expected server name dezswap-api, got %q", serverInfo.Name)
+	}
+	if serverInfo.Version != "v1.2.3" {
+		t.Fatalf("expected MCP server version v1.2.3, got %q", serverInfo.Version)
 	}
 }
 
@@ -101,7 +145,7 @@ func TestHandleTool_DispatchesToInternalRoute(t *testing.T) {
 	server, err := New(engine, Config{
 		IncludeOperations: []string{"get_service_version"},
 		ResponseMaxBytes:  1024,
-	})
+	}, "test")
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -139,7 +183,7 @@ func TestMCPOriginValidation(t *testing.T) {
 		Path:              "/mcp",
 		AllowedOrigins:    []string{"https://allowed.example.com"},
 		IncludeOperations: []string{"get_service_version"},
-	}); err != nil {
+	}, "test"); err != nil {
 		t.Fatalf("Mount() error = %v", err)
 	}
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MCP initialization reported a hardcoded server version, while the REST version endpoint used the build-injected app version. Since both surfaces represent the same deployed service, they should share the same version source.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Thread `AppVersion` into the MCP mount path.
- Use the injected version for MCP `serverInfo.version`.
- Fail MCP server creation on empty version input.
- Add coverage for version validation and initialize metadata.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now forwards the application version when starting the MCP server, so server metadata reflects the current release.
* **Bug Fixes**
  * MCP server setup now rejects missing or empty version values instead of starting with incomplete information.
  * The reported MCP server version now matches the provided application version, rather than using a fixed default.
* **Tests**
  * Added coverage for empty-version validation and version propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->